### PR TITLE
feat: [DPAV-140] load data from local file cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ result
 
 # SCI
 powerstat-*.log
+
+# Data
+/src/assets/data/*.json

--- a/src/app/core/models/runtime-configuration.model.ts
+++ b/src/app/core/models/runtime-configuration.model.ts
@@ -28,6 +28,11 @@ export interface RuntimeConfigurationModel {
     localCustodianCode: number;
     maxResults: number;
   };
+  cache: {
+    epc: string;
+    sap: string;
+    nonEpc: string;
+  };
   /* Mapbox minimap config */
   minimap: {
     zoom: number;

--- a/src/app/core/tokens/cache.token.ts
+++ b/src/app/core/tokens/cache.token.ts
@@ -1,0 +1,63 @@
+import { inject, InjectionToken } from '@angular/core';
+import { RUNTIME_CONFIGURATION } from '@core/tokens/runtime-configuration.token';
+
+/**
+ * EPC Data File Name Factory.
+ *
+ * Factory function to create a file name string.
+ */
+function epcDataFileNameFactory(): string {
+  return inject(RUNTIME_CONFIGURATION).cache.epc;
+}
+/**
+ * SAP Data File Name Factory.
+ *
+ * Factory function to create a file name string.
+ */
+function sapDataFileNameFactory(): string {
+  return inject(RUNTIME_CONFIGURATION).cache.sap;
+}
+/**
+ * Non-EPC Data File Name Factory.
+ *
+ * Factory function to create a file name string.
+ */
+function nonEpcDataFileNameFactory(): string {
+  return inject(RUNTIME_CONFIGURATION).cache.nonEpc;
+}
+
+/**
+ * EPC data file name.
+ *
+ * The file name string.
+ */
+export const EPC_DATA_FILE_NAME = new InjectionToken<string>(
+  'EPC_DATA_FILE_NAME',
+  {
+    factory: epcDataFileNameFactory,
+  }
+);
+
+/**
+ * SAP data file name.
+ *
+ * The file name string.
+ */
+export const SAP_DATA_FILE_NAME = new InjectionToken<string>(
+  'SAP_DATA_FILE_NAME',
+  {
+    factory: sapDataFileNameFactory,
+  }
+);
+
+/**
+ * Non-EPC data file name.
+ *
+ * The file name string.
+ */
+export const NON_EPC_DATA_FILE_NAME = new InjectionToken<string>(
+  'NON_EPC_DATA_FILE_NAME',
+  {
+    factory: nonEpcDataFileNameFactory,
+  }
+);

--- a/src/configurations/dev/config.json
+++ b/src/configurations/dev/config.json
@@ -8,6 +8,11 @@
     "maxResults": 100,
     "localCustodianCode": 2114
   },
+  "cache": {
+    "epc": "/assets/data/epc-data.json",
+    "sap": "/assets/data/SAP-data.json",
+    "nonEpc": "/assets/data/non-epc-data.json"
+  },
   "companyLogo": {
     "light": "assets/NDTP-HM-02-highres.png",
     "dark": "assets/NDTP-HM-04-highres.png"

--- a/src/configurations/prod/config.json
+++ b/src/configurations/prod/config.json
@@ -8,6 +8,11 @@
     "maxResults": 100,
     "localCustodianCode": 2114
   },
+  "cache": {
+    "epc": "/assets/data/epc-data.json",
+    "sap": "/assets/data/SAP-data.json",
+    "nonEpc": "/assets/data/non-epc-data.json"
+  },
   "companyLogo": {
     "light": "assets/NDTP-HM-02-highres.png",
     "dark": "assets/NDTP-HM-04-highres.png"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "lib": ["ES2022", "dom"],
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "paths": {
       "@components/*": ["src/app/components/*"],
       "@containers/*": ["src/app/containers/*"],


### PR DESCRIPTION
Load the EPC,  non-EPC and SAP data from local files (hosted as static assets) rather than querying them directly from the Integration Architecture, as a performance improvement measure.

This has been done through passing a file name as an optional parameter to the `selectTable` method, allowing us to revert to the IA by merely taking the parameter out of the method call. When evaluating the scaled solution, we can implement a feature flag that could allow us to turn the cache on and off for testing by updating Kubernetes pod environment variables.