### PR TITLE
fix(DPAV-166): generate export for a single property in a multi-property building

### DIFF
--- a/src/app/components/results-card-expandable/results-card-expandable.component.html
+++ b/src/app/components/results-card-expandable/results-card-expandable.component.html
@@ -26,6 +26,7 @@
             (toggleChecked)="toggleChecked.emit(dwelling)"
             (flag)="flag.emit([dwelling])"
             (removeFlag)="removeFlag.emit(dwelling)"
+            (downloadData)="downloadData.emit($event)"
         >
         </c477-results-card>
     }

--- a/src/app/components/results-card-expandable/results-card-expandable.component.ts
+++ b/src/app/components/results-card-expandable/results-card-expandable.component.ts
@@ -4,6 +4,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { ResultsCardComponent } from '@components/results-card/results-card.component';
 import { EPCRating } from '@core/enums';
 import { BuildingModel } from '@core/models/building.model';
+import { DownloadBuilding } from '@core/models/download-data-warning.model';
 import { UtilService } from '@core/services/utils.service';
 
 @Component({
@@ -24,6 +25,7 @@ export class ResultsCardExpandableComponent implements OnChanges {
     @Output() public flag = new EventEmitter<BuildingModel[]>();
     @Output() public removeFlag = new EventEmitter<BuildingModel>();
     @Output() public toggleChecked = new EventEmitter<BuildingModel>();
+    @Output() public downloadData: EventEmitter<DownloadBuilding> = new EventEmitter<DownloadBuilding>();
 
     public parentDataset: BuildingModel = {
         BuildForm: undefined,

--- a/src/app/containers/results-panel/results-panel.component.html
+++ b/src/app/containers/results-panel/results-panel.component.html
@@ -47,6 +47,7 @@
                                 (toggleChecked)="onToggleChecked($event)"
                                 (flag)="flag.emit($event)"
                                 (removeFlag)="removeFlag.emit($event)"
+                                (downloadData)="downloadBuilding($event)"
                             ></c477-results-card-expandable>
                         }
                     </div>


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
https://ndtp.atlassian.net/browse/DPAV-166
A defect was found where we could not generate an export for a single property that's part of a multi-property building by clicking the 'download icon'.

## Description
Forwarded the downloadData event from the expandable card component to the parent. Updated event bindings in both ResultsCardExpandableComponent and ResultsPanel for consistent handling.

## How Has This Been Tested?
Tested locally by ensuring the successful download of data for properties in both CSV and XLSX format in all scenarios - a single property-building, selecting multiple properties in a multi-property building, 'downloading all' results in a multi-property building, and also for a single-property in a multi-property building by clicking the download icon.