### PR TITLE
fix(DPAV-123): fix postcode search

### DIFF
--- a/src/app/containers/main-filters/main-filters.component.ts
+++ b/src/app/containers/main-filters/main-filters.component.ts
@@ -85,7 +85,7 @@ export class MainFiltersComponent implements OnChanges {
             distinctUntilChanged(),
             switchMap((value): Observable<AddressSearchData[]> => {
                 if (value) {
-                    return this.searchHandler(value);
+                    return this.#addressSearchService.getAddresses(value);
                 } else {
                     return of<AddressSearchData[]>([]);
                 }
@@ -109,17 +109,6 @@ export class MainFiltersComponent implements OnChanges {
 
     public getKeys(options: { [key: string]: string }): string[] {
         return Object.keys(options);
-    }
-
-    /**
-     * Conditionally handle which OS API to call depending on user input
-     * @param query address or postcode search string
-     * @returns address or postcode suggestions
-     */
-    private searchHandler(query: string): Observable<AddressSearchData[]> {
-        const isPostcode = this.checkForPostcode(query);
-        const results = isPostcode ? this.#addressSearchService.getPostCodes(query) : this.#addressSearchService.getAddresses(query);
-        return results;
     }
 
     /**
@@ -262,18 +251,5 @@ export class MainFiltersComponent implements OnChanges {
 
     public filtersExist(): boolean {
         return (this.filterProps && Object.keys(this.filterProps).length > 0) || this.#spatialQueryService.spatialFilterEnabled();
-    }
-
-    /**
-     * Check if search string is a IoW postcode.
-     * @param query search string
-     * @returns boolean
-     */
-    private checkForPostcode(query: string): boolean {
-        if (query.slice(0, 3).toLocaleLowerCase() === 'po3' || query.slice(0, 3).toLocaleLowerCase() === 'po4') {
-            return true;
-        } else {
-            return false;
-        }
     }
 }

--- a/src/app/core/services/address-search.service.ts
+++ b/src/app/core/services/address-search.service.ts
@@ -44,22 +44,6 @@ export class AddressSearchService {
             .pipe(map((res: AddressSearchResponse) => (res.results?.length ? res.results.map((r) => r.DPA) : [])));
     }
 
-    /**
-     * Free text postcode only search
-     * @param queryString postcode
-     * @returns array of suggested postcodes reformatted to match
-     * address search response
-     */
-    public getPostCodes(queryString: string): Observable<AddressSearchData[]> {
-        return this.#http
-            .get<OSNamesSearchResponse>(
-                `
-        ${this.#runtimeConfiguration.addressSearch.namesAPIURL}/find?query=${encodeURIComponent(queryString)}&maxresults=${this.#runtimeConfiguration.addressSearch.maxResults}&FQ=LOCAL_TYPE:Postcode&key=${environment.os.apiKey}
-      `,
-            )
-            .pipe(map((res: OSNamesSearchResponse) => this.convertNamesToAddresses(res)));
-    }
-
     private convertNamesToAddresses(searchResults: OSNamesSearchResponse): AddressSearchData[] {
         const results: AddressSearchData[] = [];
         if (searchResults.results.length) {


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
https://ndtp.atlassian.net/browse/DPAV-123
Previously, searching for a postcode was not functioning correctly and would fail to filter results based on the postcode as well as freeze the address search.

## Description
Swapped to using the OS Places api rather than the OS Names api for postcode searches, which is now in line with address searches. The OS Places API is also fully capable of doing postcode lookups (https://docs.os.uk/os-apis/accessing-os-apis/os-places-api). Also removed some now-redundant methods.

## How Has This Been Tested?
Tested locally to ensure a postcode search works correctly and filters out results based on the input. The address search now also no longer freezes after entering a postcode.

## Screenshots (if appropriate):
<img width="175" alt="image" src="https://github.com/user-attachments/assets/80eedbe1-7d13-438e-ad1c-c5be1239bc6e" />