### PR TITLE
fix(NON-REQ): correct colour for building selection

### DIFF
--- a/src/configurations/dev/config.json
+++ b/src/configurations/dev/config.json
@@ -135,7 +135,7 @@
             "maxzoom": 15,
             "type": "fill",
             "layout": { "visibility": "visible" },
-            "paint": { "fill-opacity": 0.8, "fill-outline-color": "#51406C" }
+            "paint": { "fill-opacity": 0.8, "fill-outline-color": "#3670b3" }
         },
         {
             "displayName": "Selected Ward",
@@ -147,7 +147,7 @@
             "type": "line",
             "filter": ["==", "WD23NM", ""],
             "layout": { "visibility": "visible" },
-            "paint": { "line-color": "#51406C", "line-width": 2 }
+            "paint": { "line-color": "#3670b3", "line-width": 2 }
         }
     ]
 }

--- a/src/configurations/prod/config.json
+++ b/src/configurations/prod/config.json
@@ -135,7 +135,7 @@
             "maxzoom": 15,
             "type": "fill",
             "layout": { "visibility": "visible" },
-            "paint": { "fill-opacity": 0.8, "fill-outline-color": "#51406C" }
+            "paint": { "fill-opacity": 0.8, "fill-outline-color": "#3670b3" }
         },
         {
             "displayName": "Selected Ward",
@@ -147,7 +147,7 @@
             "type": "line",
             "filter": ["==", "WD23NM", ""],
             "layout": { "visibility": "visible" },
-            "paint": { "line-color": "#51406C", "line-width": 2 }
+            "paint": { "line-color": "#3670b3", "line-width": 2 }
         }
     ]
 }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Summary
During recent deployment changes configs got rolled back to older colours, this corrects the colours.

## Checklist:
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- I have added tests to cover my changes.