### PR TITLE
fix(NON-REQ): prevent caching of configuration

### DIFF
--- a/k8s/visualiser/base/istio/virtualService.yaml
+++ b/k8s/visualiser/base/istio/virtualService.yaml
@@ -1,6 +1,5 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
-
 metadata:
   name: iris-visualiser
 spec:
@@ -25,6 +24,24 @@ spec:
             host: iris-visualiser
             port:
               number: 80
+
+    # Rule for /configuration paths
+    - match:
+        - uri:
+            prefix: /configuration
+      headers:
+        response:
+          add:
+            Cache-Control: "no-cache, no-store, must-revalidate"
+            Pragma: "no-cache"
+            Expires: "0"
+      route:
+        - destination:
+            host: iris-visualiser
+            port:
+              number: 80
+
+    # Rule for all other requests
     - match:
         - uri:
             prefix: /


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Prevent caching of requests to /configuration as this causes visual discrepancies when colours are updated in config files.

## Description
Prevent caching of requests to /configuration as this causes visual discrepancies when colours are updated in config files.

## How Has This Been Tested?
To be tested in remote deployment environment.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.