### PR TITLE
fix(DPAV-326): ensure filter components remain visible

### DIFF
--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -22,6 +22,8 @@ export class DataService {
     readonly #backendApiEndpoint = inject(BACKEND_API_ENDPOINT);
     readonly #runtimeConfig = inject(RUNTIME_CONFIGURATION);
 
+    public uiReady = signal<boolean>(true);
+
     public viewportBuildingsLoading = signal<boolean>(false);
     public minimalBuildings = signal<MinimalBuildingMap>({});
 
@@ -31,8 +33,8 @@ export class DataService {
     public flagHistory = signal<Loading<FlagHistory[]>>([]);
 
     public loading = computed(() => {
-        // Loading is either the initial loading state or based on viewport building loading
-        return this.viewportBuildingsLoading();
+        // Loading set to false after initial load
+        return !this.uiReady();
     });
 
     public selectedBuilding = signal<BuildingModel | undefined>(undefined);
@@ -460,7 +462,6 @@ export class DataService {
      * Clears the buildings cache
      */
     public clearBuildingsCache(): void {
-        console.log('Clearing buildings cache');
         this._buildingsCache.clear();
         this._buildingCacheOrder.length = 0;
     }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
The filter components at the top (Address search, epc rating, flags, advanced filters) would previously disappear briefly when navigating the map and loading in building data.

## Description
Change the loading signal to always be set to false after initial app load, ensuring that the UI components remain visible rather than being based on viewportBuildingsLoading which changes state.

## How Has This Been Tested?
Tested locally and ensured they remain visible.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.