### PR TITLE
fix(dpav-589): updated the sign out links response object

### DIFF
--- a/src/app/containers/shell/shell.component.ts
+++ b/src/app/containers/shell/shell.component.ts
@@ -233,7 +233,7 @@ export class ShellComponent {
     public handleSignout(): void {
         this.#signoutService.voidSession().subscribe({
             next: () => {
-                window.location.href = this.#signoutService.signoutLinks?.signoutLink?.href ?? '/';
+                window.location.href = this.#signoutService.signoutLinks?.redirectUrl?.href ?? '/';
             },
             error: (error) => {
                 console.error(error);

--- a/src/app/core/services/signout.service.ts
+++ b/src/app/core/services/signout.service.ts
@@ -3,13 +3,13 @@ import { inject, Injectable } from '@angular/core';
 import { BACKEND_API_ENDPOINT } from '@core/tokens/backend-endpoint.token';
 import { Observable, throwError } from 'rxjs';
 
-interface SignoutLink {
+interface RedirectUrl {
     href: string;
 }
 
 interface SignoutLinksResponse {
-    oauth2Signout: string;
-    signoutLink: SignoutLink;
+    oauth2SignoutUrl: string;
+    redirectUrl: RedirectUrl;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -32,7 +32,7 @@ export class SignoutService {
     // eslint-disable-next-line no-explicit-any
     public voidSession(): Observable<any> {
         if (this.signoutLinks) {
-            return this.#http.get(this.signoutLinks.oauth2Signout, { withCredentials: true });
+            return this.#http.get(this.signoutLinks.oauth2SignoutUrl, { withCredentials: true });
         }
 
         return throwError(() => new Error('No sign out links available to void the session!'));


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A change was made to the IRIS API to change the field returned as part of the signout-links response to be more appropriate to the use of those fields. This needs to be reflected in this app as it is a consumer.

## Description
<!--- Describe your changes in detail -->
- Updated the fields for the signout links response object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.