### PR TITLE
fix(dpav-589): switch to using the fetch api for voiding the session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "jszip": "3.10.1",
                 "mapbox-gl": "3.11.0",
                 "modern-normalize": "3.0.1",
-                "posthog-js": "1.236.1",
+                "posthog-js": "1.236.2",
                 "proj4": "2.15.0",
                 "rxjs": "7.8.2",
                 "tslib": "2.8.1",
@@ -17292,9 +17292,9 @@
             }
         },
         "node_modules/posthog-js": {
-            "version": "1.236.1",
-            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.236.1.tgz",
-            "integrity": "sha512-my3MGaQfBO4FOL0RAW2mCxDkivCyt8KOenYrbeES5D5wh3SQGy0OhDH3boTKO6b6dchsAjieqtOGoRFomKXZ+A==",
+            "version": "1.236.2",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.236.2.tgz",
+            "integrity": "sha512-dSPRp/2/IWxtNuNeqevJ+ueGxJfLr67YrRWfemivJ0fJseArnZp4nWvj0Qz+qIMv7TU6a0lq6dEuAoERQDb1jQ==",
             "license": "MIT",
             "dependencies": {
                 "core-js": "^3.38.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "jszip": "3.10.1",
         "mapbox-gl": "3.11.0",
         "modern-normalize": "3.0.1",
-        "posthog-js": "1.236.1",
+        "posthog-js": "1.236.2",
         "proj4": "2.15.0",
         "rxjs": "7.8.2",
         "tslib": "2.8.1",

--- a/src/app/containers/shell/shell.component.ts
+++ b/src/app/containers/shell/shell.component.ts
@@ -230,16 +230,16 @@ export class ShellComponent {
         this.menuOpened = false;
     }
 
-    public handleSignout(): void {
-        this.#signoutService.voidSession().subscribe({
-            next: () => {
+    public async handleSignout(): Promise<void> {
+        await this.#signoutService
+            .voidSession()
+            .then(() => {
                 window.location.href = this.#signoutService.signoutLinks?.redirectUrl?.href ?? '/';
-            },
-            error: (error) => {
+            })
+            .catch((error) => {
                 console.error(error);
                 window.location.href = '/';
-            },
-        });
+            });
     }
 
     private updateBuildingLayerColour(): void {

--- a/src/app/core/services/signout.service.ts
+++ b/src/app/core/services/signout.service.ts
@@ -36,7 +36,7 @@ export class SignoutService {
             return fetch(this.signoutLinks.oauth2SignoutUrl, { method: 'GET', redirect: 'manual' });
         }
 
-        return Promise.reject('No sign out links available to void the session!');
+        return Promise.reject(new Error('No sign out links available to void the session!'));
     }
 }
 

--- a/src/app/core/services/signout.service.ts
+++ b/src/app/core/services/signout.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { BACKEND_API_ENDPOINT } from '@core/tokens/backend-endpoint.token';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 
 interface RedirectUrl {
     href: string;
@@ -29,13 +29,14 @@ export class SignoutService {
         return this.#http.get<SignoutLinksResponse>(`${this.#backendApiEndpoint}/signout-links`);
     }
 
-    // eslint-disable-next-line no-explicit-any
-    public voidSession(): Observable<any> {
+    // This method uses fetch because we do not want to automatically redirect the user to the location provided
+    // by the response of the HTTP request as it will return a 302 response when successful.
+    public voidSession(): Promise<object> {
         if (this.signoutLinks) {
-            return this.#http.get(this.signoutLinks.oauth2SignoutUrl, { withCredentials: true });
+            return fetch(this.signoutLinks.oauth2SignoutUrl, { method: 'GET', redirect: 'manual' });
         }
 
-        return throwError(() => new Error('No sign out links available to void the session!'));
+        return Promise.reject('No sign out links available to void the session!');
     }
 }
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Calling the oauth2 sign out link was redirecting the user automatically to the location returned by the response of the call. We actively want to stop this as this results in incomplete sign out and instead want to redirect the user to the common sign out page provided by our IDP which is cognito atm.

## Description
<!--- Describe your changes in detail -->
- Switched to using the fetch API just for sign out which allows providing the redirect manual option to take over redirecting the user once the session has been voided
- Updated the posthog package

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.