### PR TITLE
fix(dpav-589): added include credentials header to void session call

### DIFF
--- a/src/app/core/services/signout.service.ts
+++ b/src/app/core/services/signout.service.ts
@@ -33,7 +33,7 @@ export class SignoutService {
     // by the response of the HTTP request as it will return a 302 response when successful.
     public voidSession(): Promise<object> {
         if (this.signoutLinks) {
-            return fetch(this.signoutLinks.oauth2SignoutUrl, { method: 'GET', redirect: 'manual' });
+            return fetch(this.signoutLinks.oauth2SignoutUrl, { method: 'GET', redirect: 'manual', credentials: 'include' });
         }
 
         return Promise.reject(new Error('No sign out links available to void the session!'));


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the sign out button is redirecting the user to the landing page without voiding their session by expiring the OIDC cookie. This might be happening as the `credentials: 'include'` option is not passed to the get request through the fetch API.

## Description
<!--- Describe your changes in detail -->
- Added the `credentials 'include'` option to ensure the OIDC cookie is expired.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Can only be tested when deployed.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.