### PR TITLE
feat(DPAV-1760): os ngd roof aspect ui tweak

### DIFF
--- a/src/app/components/details-panel/details-panel.component.html
+++ b/src/app/components/details-panel/details-panel.component.html
@@ -165,15 +165,6 @@
                 }
             </dd>
 
-            <dt>Roof area indeterminable (m²):</dt>
-            <dd>
-                @if (building.RoofAspectAreaIndeterminable) {
-                    {{ formatRoofAreaIndeterminable(building) }} m²
-                } @else {
-                    No data
-                }
-            </dd>
-
             <dt>Wall construction:</dt>
             <dd>
                 @if (building.WallConstruction && wall[building!.WallConstruction!]) {

--- a/src/app/components/details-panel/details-panel.component.ts
+++ b/src/app/components/details-panel/details-panel.component.ts
@@ -139,10 +139,10 @@ export class DetailsPanelComponent implements OnInit {
             if (!Number.isNaN(n)) {
                 if (n === 0) return; // skip zeros
                 const rounded = Math.round(n);
-                entries.push(`${rounded} m² ${dir}`);
+                entries.push(`${rounded}m² ${dir}`);
             } else {
                 // Non-numeric value; include as-is
-                entries.push(`${value} m² ${dir}`);
+                entries.push(`${value}m² ${dir}`);
             }
         };
         add('North', building.RoofAspectAreaNorth);
@@ -153,17 +153,8 @@ export class DetailsPanelComponent implements OnInit {
         add('South West', building.RoofAspectAreaSouthwest);
         add('West', building.RoofAspectAreaWest);
         add('North West', building.RoofAspectAreaNorthwest);
+        add('Unknown', building.RoofAspectAreaIndeterminable);
         return entries.join(', ');
-    }
-
-    public formatRoofAreaIndeterminable(building?: BuildingModel): string {
-        const val = building?.RoofAspectAreaIndeterminable;
-        if (!val) return '';
-        const n = Number(val);
-        if (!Number.isNaN(n)) {
-            return String(Math.round(n));
-        }
-        return val;
     }
 }
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->

Removes the space between roof aspect area values and the m2 unit. Also brings in area indeterminable (now shown as 'Unknown') under the general roof aspect areas heading instead of on its own. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Tested locally and shared screenshots with team to verify changes.

<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
