### PR TITLE
fix(dpav-1967): fixed aggressive rounding of epc layer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 ---
 
+
+## [0.94.4] - 2025-10-24
+
+### Bugfixes
+
+- [DPAV-1967]: Fixed aggressive rounding of epc layer histogram values
+
 ## [0.94.2] - 2025-10-23
 
 ### Bugfixes

--- a/src/app/core/pipes/number.pipe.spec.ts
+++ b/src/app/core/pipes/number.pipe.spec.ts
@@ -86,9 +86,21 @@ describe('NumberPipe', () => {
     describe('Numbers 1,000,000 and above', () => {
         it('should convert to millions with m suffix', () => {
             expect(pipe.transform(531525)).toBe('532k');
+            expect(pipe.transform(531525, 1)).toBe('531.5k');
+            expect(pipe.transform(531525, 2)).toBe('531.52k');
+            expect(pipe.transform(531526, 2)).toBe('531.53k');
+            expect(pipe.transform(561525, 1)).toBe('561.5k');
             expect(pipe.transform(1000000)).toBe('1m');
+            expect(pipe.transform(1100000, 2)).toBe('1.1m');
+            expect(pipe.transform(4999999, 1)).toBe('5m');
+            expect(pipe.transform(1550000, 1)).toBe('1.6m');
+            expect(pipe.transform(1550001, 1)).toBe('1.6m');
+            expect(pipe.transform(1550001, 2)).toBe('1.55m');
+            expect(pipe.transform(1499999, 1)).toBe('1.5m');
             expect(pipe.transform(2561562)).toBe('3m');
+            expect(pipe.transform(2561562, 1)).toBe('2.6m');
             expect(pipe.transform(63313441)).toBe('63m');
+            expect(pipe.transform(63313441, 5)).toBe('63.31344m');
         });
 
         it('should handle negative numbers in millions range', () => {
@@ -103,7 +115,7 @@ describe('NumberPipe', () => {
         });
 
         it('should apply decimal places for millions when specified', () => {
-            expect(pipe.transform(1000000, 2)).toBe('1.00m');
+            expect(pipe.transform(1000000, 2)).toBe('1m');
             expect(pipe.transform(63313441, 1)).toBe('63.3m');
             expect(pipe.transform(2561562, 2)).toBe('2.56m');
         });
@@ -126,6 +138,9 @@ describe('NumberPipe', () => {
             expect(pipe.transform(356.0)).toBe('356');
             expect(pipe.transform(10174.0)).toBe('10k');
             expect(pipe.transform(1000000.0)).toBe('1m');
+            expect(pipe.transform(356.0, 1)).toBe('356');
+            expect(pipe.transform(10174.0, 1)).toBe('10.2k');
+            expect(pipe.transform(1000000.0, 1)).toBe('1m');
         });
     });
 
@@ -140,12 +155,12 @@ describe('NumberPipe', () => {
             expect(pipe.transform(1234.567, 1)).toBe('1234.6');
             expect(pipe.transform(9999.999, 3)).toBe('9999.999');
             expect(pipe.transform(10174, 2)).toBe('10.17k');
-            expect(pipe.transform(1000000, 2)).toBe('1.00m');
+            expect(pipe.transform(1000000, 2)).toBe('1m');
         });
 
         it('should apply decimal places to all ranges when specified', () => {
             expect(pipe.transform(10174, 2)).toBe('10.17k');
-            expect(pipe.transform(1000000, 3)).toBe('1.000m');
+            expect(pipe.transform(1000000, 3)).toBe('1m');
         });
 
         it('should handle zero decimal places explicitly', () => {

--- a/src/app/core/pipes/number.pipe.ts
+++ b/src/app/core/pipes/number.pipe.ts
@@ -18,26 +18,44 @@ export class NumberPipe implements PipeTransform {
 
         if (absValue < 10000) {
             if (decimals > 0) {
-                result = absValue.toFixed(decimals);
+                result = this.fixedPointString(absValue, decimals, '');
             } else {
                 result = Math.round(absValue).toString();
             }
         } else if (absValue < 1000000) {
             const thousands = absValue / 1000;
             if (decimals > 0) {
-                result = thousands.toFixed(decimals) + 'k';
+                result = this.fixedPointString(thousands, decimals, 'k');
             } else {
                 result = Math.round(thousands) + 'k';
             }
         } else {
             const millions = absValue / 1000000;
             if (decimals > 0) {
-                result = millions.toFixed(decimals) + 'm';
+                result = this.fixedPointString(millions, decimals, 'm');
             } else {
                 result = Math.round(millions) + 'm';
             }
         }
 
         return isNegative ? '-' + result : result;
+    }
+
+    private fixedPointString(num: number, decimals: number, ordinal: string): string {
+        if (num % 1 === 0) {
+            return `${Math.trunc(num).toString()}${ordinal}`;
+        }
+
+        const fixedNum = num.toFixed(decimals);
+
+        if (fixedNum.includes('.')) {
+            const allZerosAfterDecimalPoint = /\.?0+$/;
+
+            if (allZerosAfterDecimalPoint.test(fixedNum)) {
+                return `${fixedNum.replace(allZerosAfterDecimalPoint, '')}${ordinal}`;
+            }
+        }
+
+        return `${num.toFixed(decimals)}${ordinal}`;
     }
 }

--- a/src/app/core/services/layers/epc.layer.ts
+++ b/src/app/core/services/layers/epc.layer.ts
@@ -203,7 +203,7 @@ export class EPCLayer extends AbstractBaseLayer {
             labels.push(label);
             return `
                 <div class="bar" style="height: calc(${height}% + 5px)">
-                    <span class="rating">${numberPipe.transform(r.count)}</span>
+                    <span class="rating">${numberPipe.transform(r.count, 1)}</span>
                     <div class="line" style="background: ${this.getEPCColour(r.rating)}"></div>
                 </div>
             `;


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The values on the EPC analytics layer histogram was aggressively rounding values over 1m leading to inaccurate results.

## Description
<!--- Describe your changes in detail -->
- Refactored transformation function to round properly given 1 or more decimal places.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and through unit test and is working as expected.

## Screenshots (if appropriate):
<img width="1904" height="905" alt="image" src="https://github.com/user-attachments/assets/54cde589-4dfe-4211-87a7-c7fd390e5d3d" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
