### PR TITLE
feat(DPAV-1688): disable layer click handlers when drawing

### DIFF
--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -266,6 +266,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             case 'polygon': {
                 this.deleteSearchArea();
                 this.drawActive = true;
+                this.#mapService.setDrawing(true);
                 this.updateMode('draw_polygon');
                 break;
             }
@@ -296,6 +297,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             this.deleteSearchArea();
             this.isDrawingForDashboard = true;
             this.drawActive = true;
+            this.#mapService.setDrawing(true);
             this.updateMode('draw_polygon');
         }
     }
@@ -446,6 +448,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     public deleteSearchArea(): void {
         this.drawActive = false;
         this.isDrawingForDashboard = false;
+        this.#mapService.setDrawing(false);
         this.drawControl?.deleteAll();
         this.deleteSpatialFilter.emit(null);
     }
@@ -456,6 +459,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
      */
     private onDrawCreate(e: MapboxDraw.DrawCreateEvent): void {
         this.drawActive = false;
+        this.#mapService.setDrawing(false);
         const polygon = e.features[0] as GeoJSON.Feature<Polygon>;
 
         if (this.isDrawingForDashboard) {
@@ -484,6 +488,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         if (e.mode === 'simple_select' && this.drawActive) {
             this.drawActive = false;
             this.isDrawingForDashboard = false;
+            this.#mapService.setDrawing(false);
             this.#changeDetectorRef.detectChanges();
         }
     }
@@ -497,7 +502,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     }
 
     private setSelectedTOID(e: MapMouseEvent): void {
-        if (e.features && this.drawControl?.getMode() !== 'draw_polygon') {
+        if (e.features && !this.#mapService.isDrawing()) {
             this.setSelectedBuildingTOID.emit(e.features![0].properties!.TOID);
         }
     }

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -266,7 +266,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             case 'polygon': {
                 this.deleteSearchArea();
                 this.drawActive = true;
-                this.#mapService.setDrawing(true);
+                this.#mapService.startDrawing();
                 this.updateMode('draw_polygon');
                 break;
             }
@@ -297,7 +297,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             this.deleteSearchArea();
             this.isDrawingForDashboard = true;
             this.drawActive = true;
-            this.#mapService.setDrawing(true);
+            this.#mapService.startDrawing();
             this.updateMode('draw_polygon');
         }
     }
@@ -448,7 +448,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     public deleteSearchArea(): void {
         this.drawActive = false;
         this.isDrawingForDashboard = false;
-        this.#mapService.setDrawing(false);
+        this.#mapService.stopDrawing();
         this.drawControl?.deleteAll();
         this.deleteSpatialFilter.emit(null);
     }
@@ -459,7 +459,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
      */
     private onDrawCreate(e: MapboxDraw.DrawCreateEvent): void {
         this.drawActive = false;
-        this.#mapService.setDrawing(false);
+        this.#mapService.stopDrawing();
         const polygon = e.features[0] as GeoJSON.Feature<Polygon>;
 
         if (this.isDrawingForDashboard) {
@@ -488,7 +488,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         if (e.mode === 'simple_select' && this.drawActive) {
             this.drawActive = false;
             this.isDrawingForDashboard = false;
-            this.#mapService.setDrawing(false);
+            this.#mapService.stopDrawing();
             this.#changeDetectorRef.detectChanges();
         }
     }

--- a/src/app/core/services/layers/base-layer.abstract.ts
+++ b/src/app/core/services/layers/base-layer.abstract.ts
@@ -77,7 +77,12 @@ export abstract class AbstractBaseLayer implements BaseLayer {
                         this.mapService.mapInstance.off('click', layerConfig.id, this.boundClickHandler);
                     }
 
-                    this.boundClickHandler = this.onLayerClick.bind(this);
+                    this.boundClickHandler = (event: MapMouseEvent): void => {
+                        if (this.mapService.isDrawing() || !this.onLayerClick) {
+                            return;
+                        }
+                        this.onLayerClick(event);
+                    };
                     this.mapService.mapInstance.on('click', layerConfig.id, this.boundClickHandler);
                 }
             }

--- a/src/app/core/services/layers/base-layer.abstract.ts
+++ b/src/app/core/services/layers/base-layer.abstract.ts
@@ -44,11 +44,11 @@ export abstract class AbstractBaseLayer implements BaseLayer {
             this.closeLegend();
 
             const allLayers = AbstractBaseLayer.layerFactory.getAllLayers();
-            allLayers.forEach((layer: BaseLayer) => {
+            for (const layer of allLayers) {
                 if (layer.id !== this.id && layer.isVisible) {
                     layer.hide();
                 }
-            });
+            }
         }
     }
 
@@ -110,7 +110,9 @@ export abstract class AbstractBaseLayer implements BaseLayer {
 
     private closeAllPopups(): void {
         const popups = document.querySelectorAll('.mapboxgl-popup');
-        popups.forEach((popup) => popup.remove());
+        for (const popup of Array.from(popups)) {
+            popup.remove();
+        }
     }
 
     private closeLegend(): void {

--- a/src/app/core/services/map.service.ts
+++ b/src/app/core/services/map.service.ts
@@ -30,6 +30,7 @@ export class MapBoxService implements MapService<mapboxgl.Map> {
     public currentMapBounds = signal<LngLatBounds | undefined>(undefined);
 
     private mapLoaded: AsyncSubject<boolean>;
+    private _isDrawing: boolean = false;
 
     constructor() {
         this.mapLoaded = new AsyncSubject<boolean>();
@@ -211,6 +212,22 @@ export class MapBoxService implements MapService<mapboxgl.Map> {
             minLng: bounds.getWest(),
             maxLng: bounds.getEast(),
         };
+    }
+
+    public setDrawing(isDrawing: boolean): void {
+        if (!isDrawing && this._isDrawing) {
+            // delay to avoid immediate click event when drawing is completed
+            // don't create a timeout if we're not drawing though as this causes a race condition
+            setTimeout(() => {
+                this._isDrawing = false;
+            }, 0);
+        } else {
+            this._isDrawing = true;
+        }
+    }
+
+    public isDrawing(): boolean {
+        return this._isDrawing;
     }
 
     public addDrawControl(): MapboxDraw {

--- a/src/app/core/services/map.service.ts
+++ b/src/app/core/services/map.service.ts
@@ -214,15 +214,17 @@ export class MapBoxService implements MapService<mapboxgl.Map> {
         };
     }
 
-    public setDrawing(isDrawing: boolean): void {
-        if (!isDrawing && this._isDrawing) {
+    public startDrawing(): void {
+        this._isDrawing = true;
+    }
+
+    public stopDrawing(): void {
+        if (this._isDrawing) {
             // delay to avoid immediate click event when drawing is completed
             // don't create a timeout if we're not drawing though as this causes a race condition
             setTimeout(() => {
                 this._isDrawing = false;
             }, 0);
-        } else {
-            this._isDrawing = true;
         }
     }
 

--- a/src/app/core/services/map.token.ts
+++ b/src/app/core/services/map.token.ts
@@ -35,6 +35,10 @@ export interface MapService<T> {
 
     setup: (config: URLStateModel) => void;
 
+    setDrawing: (isDrawing: boolean) => void;
+
+    isDrawing: () => boolean;
+
     addMapSource(name: string, source: unknown): T;
 
     addMapLayer(layerConfig: unknown): T;

--- a/src/app/core/services/map.token.ts
+++ b/src/app/core/services/map.token.ts
@@ -35,8 +35,8 @@ export interface MapService<T> {
 
     setup: (config: URLStateModel) => void;
 
-    setDrawing: (isDrawing: boolean) => void;
-
+    startDrawing: () => void;
+    stopDrawing: () => void;
     isDrawing: () => boolean;
 
     addMapSource(name: string, source: unknown): T;


### PR DESCRIPTION
Setting the flag to false in a setTimeout to avoid the final click to end the drawing triggering a layer pop up at the same time.

## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
When drawing on the map to select an area for the dashboard clicking the next point pops up the layer info for the area.
This issue also happened on the existing draw area functionality.

## Description
Don't handle click events when drawing.

## How Has This Been Tested?
Locally


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
