### PR TITLE
feat(DPAV-1970): add info text to Area view button

### DIFF
--- a/src/app/components/map/map.component.html
+++ b/src/app/components/map/map.component.html
@@ -127,7 +127,10 @@
                 @if (hasSpatialFilter) {
                     <button mat-menu-item (click)="handleDashboardAreaClick()">
                         <mat-icon>map</mat-icon>
-                        <span>Area view</span>
+                        <div class="menu-item-text">
+                            <span class="main-text">Area view</span>
+                            <span class="info-text">For drawn polygon</span>
+                        </div>
                     </button>
                 } @else {
                     <button mat-menu-item (click)="handleDashboardAreaClick()">

--- a/src/app/components/map/map.component.scss
+++ b/src/app/components/map/map.component.scss
@@ -79,35 +79,60 @@
     }
 }
 
-.layers-menu {
-    .mat-mdc-menu-panel {
+::ng-deep .layers-menu {
+    &.mat-mdc-menu-panel {
         &.mat-menu-before {
             position: absolute;
             top: 0;
             right: 1rem;
         }
+    }
 
-        .menu-section {
-            border-bottom: 1px solid var(--mat-sys-outline-variant);
+    .menu-section {
+        border-bottom: 1px solid var(--mat-sys-outline-variant);
 
-            &:last-child {
-                border-bottom: none;
+        &:last-child {
+            border-bottom: none;
+        }
+    }
+
+    .mat-mdc-menu-item {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+
+        mat-icon {
+            margin-right: 0;
+        }
+
+        .mat-mdc-menu-item-text {
+            .menu-item-text {
+                display: flex;
+                flex-direction: column;
+                gap: 0;
+                align-items: flex-start;
+
+                line-height: 1.2;
+            }
+
+            .main-text {
+                font-weight: var(--mat-sys-label-large-weight);
+            }
+
+            .info-text {
+                margin-top: 2px;
+
+                font-size: 0.75rem;
+                line-height: 1;
+                color: var(--mat-sys-on-surface-variant);
+
+                opacity: 0.7;
             }
         }
 
-        .mat-mdc-menu-item {
-            display: flex;
-            gap: 12px;
-            align-items: center;
-
-            mat-icon {
-                margin-right: 0;
-            }
-
-            &.active {
-                color: var(--mat-sys-on-primary-container);
-                background-color: var(--mat-sys-primary-container);
-            }
+        &.active {
+            color: var(--mat-sys-on-primary-container);
+            background-color: var(--mat-sys-primary-container);
         }
     }
 }


### PR DESCRIPTION
Adds "For drawn polygon" text under the button to indicate that it will navigate you to the already drawn polygon

## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Indicate Area view button is for the already selected area

https://ndtp.atlassian.net/browse/DPAV-1970

## Description
Adds "For drawn polygon" text under the button to indicate that it will navigate you to the already drawn polygon


## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
<img width="215" height="169" alt="Screenshot 2025-11-17 at 10 56 03" src="https://github.com/user-attachments/assets/7a0b9085-4749-478f-9a8f-03df83a7d443" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
