### PR TITLE
feat(DPAV-1954): add custom scrollbar to epc-by-area-chart

### DIFF
--- a/src/app/containers/dashboard/charts/_chart-shared.scss
+++ b/src/app/containers/dashboard/charts/_chart-shared.scss
@@ -12,6 +12,26 @@
     }
 }
 
+.chart-with-scrollbar {
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+
+    plotly-plot {
+        width: 100%;
+        // Prevent Plotly's drag cursor when dragmode is disabled
+        ::ng-deep .drag {
+            cursor: default !important;
+        }
+    }
+}
+
+.chart-scrollbar {
+    display: flex;
+    align-items: center;
+    width: 12px;
+}
+
 ::ng-deep .plotly .legend {
     .legendpoints path {
         --circle-r6: path('M 6 0 A 6 6 0 1 1 -6 0 A 6 6 0 1 1 6 0 Z');

--- a/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.html
+++ b/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.html
@@ -3,7 +3,6 @@
         <span>{{ chartTitle() }}</span>
         <c477-area-selector
             [label]="selectorLabel()"
-            [singularLabel]="true"
             [disabled]="loading() || !!error()"
             [selectedAreas]="selectedAreas()"
             [availableAreas]="availableAreas()"

--- a/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.html
+++ b/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.html
@@ -19,7 +19,14 @@
     @if (loading() || error()) {
         <c477-chart-placeholder [error]="error()" [onRetry]="retry.bind(this)" />
     } @else {
-        <plotly-plot [data]="chartData()" [layout]="chartLayout()" [config]="chartConfig"></plotly-plot>
+        <div class="chart-with-scrollbar" (wheel)="onChartWheel($event)">
+            <plotly-plot [data]="chartData()" [layout]="chartLayout()" [config]="chartConfig"></plotly-plot>
+            @if (scrollMetrics.needsScroll) {
+                <div class="chart-scrollbar">
+                    <c477-chart-scrollbar [position]="scrollPosition()" [metrics]="scrollMetrics" (positionChange)="onScrollPositionChange($event)" />
+                </div>
+            }
+        </div>
     }
 </div>
 

--- a/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.scss
+++ b/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.scss
@@ -1,1 +1,5 @@
 @import '../chart-shared';
+
+.chart-scrollbar {
+    padding: 20px 2px 60px;
+}

--- a/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.spec.ts
@@ -390,6 +390,123 @@ describe('EpcByAreaChartComponent', () => {
             expect(component.selectedAreas()).toEqual([]);
         });
     });
+
+    describe('Scrolling behavior', () => {
+        const createManyAreas = (count: number): EPCAreaData[] => {
+            return Array.from({ length: count }, (_, i) => ({
+                name: `Area ${i + 1}`,
+                epc_a: 10 * (i + 1),
+                epc_b: 20 * (i + 1),
+                epc_c: 30 * (i + 1),
+                epc_d: 40 * (i + 1),
+                epc_e: 50 * (i + 1),
+                epc_f: 60 * (i + 1),
+                epc_g: 70 * (i + 1),
+                total: 280 * (i + 1),
+            }));
+        };
+
+        it('should not need scrolling when items fit within maxVisibleItems', () => {
+            const fewAreas = createManyAreas(5);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(fewAreas));
+
+            fixture.detectChanges();
+
+            expect(component.scrollMetrics.needsScroll).toBe(false);
+        });
+
+        it('should need scrolling when items exceed maxVisibleItems', () => {
+            const manyAreas = createManyAreas(20);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(manyAreas));
+
+            fixture.detectChanges();
+
+            expect(component.scrollMetrics.needsScroll).toBe(true);
+            expect(component.scrollMetrics.maxScroll).toBe(10); // 20 - 10 maxVisibleItems
+        });
+
+        it('should initialize scroll to show top (largest values first)', () => {
+            const manyAreas = createManyAreas(20);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(manyAreas));
+
+            fixture.detectChanges();
+
+            // Should be at max scroll position
+            expect(component.scrollPosition()).toBe(component.scrollMetrics.maxScroll);
+        });
+
+        it('should clamp scroll position when hiding areas reduces total below current position', () => {
+            const manyAreas = createManyAreas(20);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(manyAreas));
+
+            fixture.detectChanges();
+
+            // Start at max scroll (10)
+            expect(component.scrollPosition()).toBe(10);
+
+            // Hide most areas, leaving only 5
+            component.selectedAreas.set(manyAreas.slice(0, 5).map((a) => a.name));
+            fixture.detectChanges();
+
+            // Should clamp to 0 since 5 items don't need scroll
+            expect(component.scrollPosition()).toBe(0);
+        });
+
+        it('should update scroll position via onScrollPositionChange', () => {
+            const manyAreas = createManyAreas(20);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(manyAreas));
+
+            fixture.detectChanges();
+
+            component.onScrollPositionChange(5);
+
+            expect(component.scrollPosition()).toBe(5);
+        });
+
+        it('should clamp scroll position to valid bounds', () => {
+            const manyAreas = createManyAreas(20);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(manyAreas));
+
+            fixture.detectChanges();
+
+            // Try to scroll past max
+            component.onScrollPositionChange(100);
+            expect(component.scrollPosition()).toBe(10);
+
+            // Try to scroll below 0
+            component.onScrollPositionChange(-5);
+            expect(component.scrollPosition()).toBe(0);
+        });
+
+        it('should handle wheel scroll events', () => {
+            const manyAreas = createManyAreas(20);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(manyAreas));
+
+            fixture.detectChanges();
+
+            // Start at max (10)
+            expect(component.scrollPosition()).toBe(10);
+
+            // Scroll down (positive deltaY) should decrease position
+            const scrollDownEvent = new WheelEvent('wheel', { deltaY: 100 });
+            component.onChartWheel(scrollDownEvent);
+
+            expect(component.scrollPosition()).toBe(9);
+        });
+
+        it('should not handle wheel events when scrolling not needed', () => {
+            const fewAreas = createManyAreas(5);
+            jest.spyOn(dashboardService, 'getEPCByAreaLevel').mockReturnValue(of(fewAreas));
+
+            fixture.detectChanges();
+
+            const initialPosition = component.scrollPosition();
+            const scrollEvent = new WheelEvent('wheel', { deltaY: 100 });
+            component.onChartWheel(scrollEvent);
+
+            expect(component.scrollPosition()).toBe(initialPosition);
+        });
+    });
 });
 
 // SPDX-License-Identifier: Apache-2.0

--- a/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.ts
+++ b/src/app/containers/dashboard/charts/epc-by-area-chart/epc-by-area-chart.component.ts
@@ -6,22 +6,27 @@ import { AreaLevel } from '@core/models/area-filter.model';
 import { EPCAreaData } from '@core/services/dashboard.service';
 import { PlotlyModule } from 'angular-plotly.js';
 import type { Data, Layout } from 'plotly.js-dist-min';
-import { BaseChartComponent } from '../base-chart.component';
 import { AreaSelectorComponent } from '../shared/area-selector.component';
 import { ChartPlaceholderComponent } from '../shared/chart-placeholder.component';
+import { ChartScrollbarComponent } from '../shared/chart-scrollbar.component';
+import { ScrollableChartComponent } from '../shared/scrollable-chart.component';
 
 @Component({
     selector: 'c477-epc-by-area-chart',
-    imports: [CommonModule, PlotlyModule, MatFormFieldModule, MatSelectModule, AreaSelectorComponent, ChartPlaceholderComponent],
+    imports: [CommonModule, PlotlyModule, MatFormFieldModule, MatSelectModule, AreaSelectorComponent, ChartPlaceholderComponent, ChartScrollbarComponent],
     templateUrl: './epc-by-area-chart.component.html',
     styleUrl: './epc-by-area-chart.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class EpcByAreaChartComponent extends BaseChartComponent {
+export class EpcByAreaChartComponent extends ScrollableChartComponent {
+    protected readonly maxVisibleItems = 10;
+    protected readonly totalItems = (): number => this.selectedAreas().length;
+
     public chartData = signal<Data[]>([]);
     public chartLayout = signal<Partial<Layout>>({});
     public availableAreas = signal<string[]>([]);
     public selectedAreas = signal<string[]>([]);
+
     private readonly epcAreaData = signal<EPCAreaData[] | null>(null);
 
     private readonly groupingConfig = computed(() => {
@@ -87,6 +92,8 @@ export class EpcByAreaChartComponent extends BaseChartComponent {
                 return;
             }
 
+            this.clampScrollPosition();
+
             const built = this.buildChart(data, areas);
             this.chartData.set(built.data);
             this.chartLayout.set(built.layout);
@@ -102,6 +109,8 @@ export class EpcByAreaChartComponent extends BaseChartComponent {
             const areas = areaData.map((r) => r.name);
             this.availableAreas.set(areas);
             this.selectedAreas.set(areas);
+
+            this.initializeScrollToTop();
         });
     }
 
@@ -146,13 +155,17 @@ export class EpcByAreaChartComponent extends BaseChartComponent {
                 showgrid: false,
                 linecolor: '#e0e0e0',
                 zerolinecolor: '#e0e0e0',
+                fixedrange: true,
             },
             yaxis: {
                 title: { text: '' },
                 tickfont: { size: 11, color: '#999' },
                 automargin: true,
                 linecolor: '#e0e0e0',
+                range: this.getAxisRange(),
+                fixedrange: true,
             },
+            dragmode: false,
             font: this.chartService.commonFont,
             height: 400,
             plot_bgcolor: 'white',
@@ -160,8 +173,9 @@ export class EpcByAreaChartComponent extends BaseChartComponent {
             showlegend: true,
             legend: {
                 orientation: 'h',
-                x: 0.3,
-                xanchor: 'center',
+                x: -1,
+                xref: 'paper',
+                xanchor: 'left',
                 traceorder: 'normal',
             },
         };

--- a/src/app/containers/dashboard/charts/shared/chart-scrollbar.component.scss
+++ b/src/app/containers/dashboard/charts/shared/chart-scrollbar.component.scss
@@ -1,0 +1,47 @@
+:host {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 100%;
+    height: 100%;
+}
+
+.scrollbar-track {
+    cursor: pointer;
+
+    position: relative;
+
+    width: 8px;
+    height: 100%;
+    border-radius: 4px;
+
+    background: #f0f0f0;
+}
+
+.scrollbar-thumb {
+    cursor: grab;
+
+    position: absolute;
+
+    width: 100%;
+    min-height: 20px;
+    border-radius: 4px;
+
+    background: #c0c0c0;
+
+    transition: background 0.15s ease;
+
+    &:hover {
+        background: #a0a0a0;
+    }
+
+    &:active {
+        cursor: grabbing;
+        background: #808080;
+    }
+}
+
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.

--- a/src/app/containers/dashboard/charts/shared/chart-scrollbar.component.spec.ts
+++ b/src/app/containers/dashboard/charts/shared/chart-scrollbar.component.spec.ts
@@ -1,0 +1,135 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChartScrollbarComponent } from './chart-scrollbar.component';
+import { ScrollMetrics } from './scrollable-chart.component';
+
+describe('ChartScrollbarComponent', () => {
+    let component: ChartScrollbarComponent;
+    let fixture: ComponentFixture<ChartScrollbarComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [ChartScrollbarComponent],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ChartScrollbarComponent);
+        component = fixture.componentInstance;
+    });
+
+    describe('thumb visibility', () => {
+        it('should hide thumb when scrolling is not needed', () => {
+            const metrics: ScrollMetrics = { totalItems: 5, visibleItems: 10, needsScroll: false, maxScroll: 0 };
+            fixture.componentRef.setInput('position', 0);
+            fixture.componentRef.setInput('metrics', metrics);
+            fixture.detectChanges();
+
+            expect(component.thumbStyle()).toEqual({ display: 'none' });
+        });
+
+        it('should show thumb when scrolling is needed', () => {
+            const metrics: ScrollMetrics = { totalItems: 20, visibleItems: 10, needsScroll: true, maxScroll: 10 };
+            fixture.componentRef.setInput('position', 0);
+            fixture.componentRef.setInput('metrics', metrics);
+            fixture.detectChanges();
+
+            const style = component.thumbStyle();
+            expect(style).toHaveProperty('height');
+            expect(style).toHaveProperty('top');
+        });
+    });
+
+    describe('thumb size', () => {
+        it('should have larger thumb when fewer items to scroll', () => {
+            const fewItems: ScrollMetrics = { totalItems: 12, visibleItems: 10, needsScroll: true, maxScroll: 2 };
+            const manyItems: ScrollMetrics = { totalItems: 50, visibleItems: 10, needsScroll: true, maxScroll: 40 };
+
+            fixture.componentRef.setInput('position', 0);
+            fixture.componentRef.setInput('metrics', fewItems);
+            fixture.detectChanges();
+            const fewItemsHeight = parseFloat((component.thumbStyle() as { height: string }).height);
+
+            fixture.componentRef.setInput('metrics', manyItems);
+            fixture.detectChanges();
+            const manyItemsHeight = parseFloat((component.thumbStyle() as { height: string }).height);
+
+            expect(fewItemsHeight).toBeGreaterThan(manyItemsHeight);
+        });
+
+        it('should have minimum thumb height of 10%', () => {
+            const metrics: ScrollMetrics = { totalItems: 1000, visibleItems: 10, needsScroll: true, maxScroll: 990 };
+            fixture.componentRef.setInput('position', 0);
+            fixture.componentRef.setInput('metrics', metrics);
+            fixture.detectChanges();
+
+            const height = parseFloat((component.thumbStyle() as { height: string }).height);
+            expect(height).toBeGreaterThanOrEqual(10);
+        });
+    });
+
+    describe('thumb position', () => {
+        it('should position thumb at top when at max scroll (showing highest values)', () => {
+            const metrics: ScrollMetrics = { totalItems: 20, visibleItems: 10, needsScroll: true, maxScroll: 10 };
+            fixture.componentRef.setInput('position', 10); // max scroll
+            fixture.componentRef.setInput('metrics', metrics);
+            fixture.detectChanges();
+
+            const top = parseFloat((component.thumbStyle() as { top: string }).top);
+            expect(top).toBe(0);
+        });
+
+        it('should position thumb at bottom when at position 0 (showing lowest values)', () => {
+            const metrics: ScrollMetrics = { totalItems: 20, visibleItems: 10, needsScroll: true, maxScroll: 10 };
+            fixture.componentRef.setInput('position', 0);
+            fixture.componentRef.setInput('metrics', metrics);
+            fixture.detectChanges();
+
+            const style = component.thumbStyle() as { top: string; height: string };
+            const top = parseFloat(style.top);
+            const height = parseFloat(style.height);
+            // Thumb should be at bottom: top + height ≈ 100%
+            expect(top + height).toBeCloseTo(100, 0);
+        });
+    });
+
+    describe('position change events', () => {
+        it('should emit position change on track click', () => {
+            const metrics: ScrollMetrics = { totalItems: 20, visibleItems: 10, needsScroll: true, maxScroll: 10 };
+            fixture.componentRef.setInput('position', 5);
+            fixture.componentRef.setInput('metrics', metrics);
+            fixture.detectChanges();
+
+            const emittedPositions: number[] = [];
+            component.positionChange.subscribe((pos) => emittedPositions.push(pos));
+
+            const track = fixture.nativeElement.querySelector('.scrollbar-track');
+
+            // Mock getBoundingClientRect since JSDOM returns 0s
+            jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+                top: 0,
+                left: 0,
+                bottom: 100,
+                right: 10,
+                width: 10,
+                height: 100,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+            });
+
+            // Simulate click at top of track (clientY = 0)
+            const clickEvent = new MouseEvent('mousedown', {
+                clientX: 5,
+                clientY: 0,
+                bubbles: true,
+            });
+            track.dispatchEvent(clickEvent);
+
+            expect(emittedPositions.length).toBeGreaterThan(0);
+            // Click at top should give max scroll position
+            expect(emittedPositions[0]).toBe(10);
+        });
+    });
+});
+
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.

--- a/src/app/containers/dashboard/charts/shared/chart-scrollbar.component.ts
+++ b/src/app/containers/dashboard/charts/shared/chart-scrollbar.component.ts
@@ -1,0 +1,74 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, output, ViewChild } from '@angular/core';
+import { ScrollMetrics } from './scrollable-chart.component';
+
+@Component({
+    selector: 'c477-chart-scrollbar',
+    standalone: true,
+    imports: [CommonModule],
+    template: `
+        <div #track class="scrollbar-track" (mousedown)="onMouseDown($event)">
+            <div class="scrollbar-thumb" [ngStyle]="thumbStyle()"></div>
+        </div>
+    `,
+    styleUrl: './chart-scrollbar.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChartScrollbarComponent {
+    private readonly destroyRef = inject(DestroyRef);
+
+    @ViewChild('track') private readonly track?: ElementRef<HTMLDivElement>;
+
+    public readonly position = input.required<number>();
+    public readonly metrics = input.required<ScrollMetrics>();
+    public readonly positionChange = output<number>();
+
+    public readonly thumbStyle = computed(() => {
+        const { needsScroll, visibleItems, totalItems, maxScroll } = this.metrics();
+        if (!needsScroll) {
+            return { display: 'none' };
+        }
+
+        const heightPercent = Math.max((visibleItems / totalItems) * 100, 10);
+        const topPercent = ((maxScroll - this.position()) / maxScroll) * (100 - heightPercent);
+
+        return {
+            height: `${heightPercent}%`,
+            top: `${topPercent}%`,
+        };
+    });
+
+    public onMouseDown(event: MouseEvent): void {
+        event.preventDefault();
+
+        const track = this.track?.nativeElement;
+        if (!track) return;
+
+        const { maxScroll } = this.metrics();
+
+        const toScrollPosition = (e: MouseEvent): number => {
+            const rect = track.getBoundingClientRect();
+            const ratio = (e.clientY - rect.top) / rect.height;
+            // Top of track = max scroll, bottom = 0 (inverted)
+            const position = (1 - ratio) * maxScroll;
+            return Math.max(0, Math.min(maxScroll, Math.round(position)));
+        };
+
+        this.positionChange.emit(toScrollPosition(event));
+
+        const onMove = (e: MouseEvent): void => this.positionChange.emit(toScrollPosition(e));
+
+        const cleanup = (): void => {
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', cleanup);
+        };
+
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', cleanup);
+        this.destroyRef.onDestroy(cleanup);
+    }
+}
+
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.

--- a/src/app/containers/dashboard/charts/shared/scrollable-chart.component.ts
+++ b/src/app/containers/dashboard/charts/shared/scrollable-chart.component.ts
@@ -1,0 +1,79 @@
+import { Directive, signal } from '@angular/core';
+import { BaseChartComponent } from '../base-chart.component';
+
+export interface ScrollMetrics {
+    totalItems: number;
+    visibleItems: number;
+    needsScroll: boolean;
+    maxScroll: number;
+}
+
+@Directive()
+export abstract class ScrollableChartComponent extends BaseChartComponent {
+    protected abstract readonly maxVisibleItems: number;
+    protected abstract readonly totalItems: () => number;
+
+    // Position 0 = bottom of data, maxScroll = top (inverted for Y-axis)
+    public readonly scrollPosition = signal<number>(0);
+
+    public get scrollMetrics(): ScrollMetrics {
+        const totalItems = this.totalItems();
+        const needsScroll = totalItems > this.maxVisibleItems;
+        const maxScroll = Math.max(0, totalItems - this.maxVisibleItems);
+        return { totalItems, visibleItems: this.maxVisibleItems, needsScroll, maxScroll };
+    }
+
+    public override readonly chartConfig = {
+        responsive: true,
+        displayModeBar: false,
+        displaylogo: false,
+        doubleClick: false as const,
+        scrollZoom: false,
+    };
+
+    // The -0.5 offset centers bars within their category position
+    protected getAxisRange(): [number, number] {
+        const { needsScroll, totalItems } = this.scrollMetrics;
+        if (!needsScroll) {
+            return [-0.5, totalItems - 0.5];
+        }
+        const pos = this.scrollPosition();
+        return [pos - 0.5, pos + this.maxVisibleItems - 0.5];
+    }
+
+    protected clampScrollPosition(): void {
+        const { maxScroll } = this.scrollMetrics;
+        if (this.scrollPosition() > maxScroll) {
+            this.scrollPosition.set(maxScroll);
+        }
+    }
+
+    protected initializeScrollToTop(): void {
+        this.scrollPosition.set(this.scrollMetrics.maxScroll);
+    }
+
+    public onScrollPositionChange(position: number): void {
+        this.scrollPosition.set(this.clamp(position));
+    }
+
+    public onChartWheel(event: WheelEvent): void {
+        if (!this.scrollMetrics.needsScroll) return;
+
+        event.preventDefault();
+
+        const delta = event.deltaY > 0 ? -1 : 1;
+        const newPosition = this.clamp(this.scrollPosition() + delta);
+
+        if (newPosition !== this.scrollPosition()) {
+            this.scrollPosition.set(newPosition);
+        }
+    }
+
+    private clamp(position: number): number {
+        return Math.max(0, Math.min(this.scrollMetrics.maxScroll, Math.round(position)));
+    }
+}
+
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.


### PR DESCRIPTION
This isn't a feature supported by Plotly, so adds custom scrollbar using a fixed range on the axis.

## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
There are too many items in this chart which causes it to be too compacted and the axis labels not lining up.
https://ndtp.atlassian.net/browse/DPAV-1954
## Description
Add custom scrollbar to the chart

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
<img width="528" height="480" alt="Screenshot 2025-11-26 at 15 38 32" src="https://github.com/user-attachments/assets/7e30e2e4-18c7-461f-9f3c-8491edb1cfcb" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
