### PR TITLE
fix(DPAV-1955): aggregate fuel type labels

### DIFF
--- a/src/app/containers/dashboard/charts/building-fuel-chart/building-fuel-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/building-fuel-chart/building-fuel-chart.component.spec.ts
@@ -168,4 +168,58 @@ describe('BuildingFuelChartComponent', () => {
             expect(flatData).not.toEqual(houseData);
         });
     });
+
+    describe('fuel type ordering', () => {
+        it('should not have duplicate labels due to Fuel and Other both mapping to "Other"', () => {
+            const realWorldData: BackendFuelTypesByBuildingTypeResponse[] = [
+                { building_type: 'House', fuel_type: 'NaturalFuelGas', count: 16674 },
+                { building_type: 'House', fuel_type: 'Oil', count: 1658 },
+                { building_type: 'House', fuel_type: 'Electricity', count: 1252 },
+                { building_type: 'House', fuel_type: 'LPG', count: 428 },
+                { building_type: 'House', fuel_type: 'Other', count: 70 },
+                { building_type: 'House', fuel_type: 'WoodLogs', count: 38 },
+                { building_type: 'House', fuel_type: 'Coal', count: 18 },
+                { building_type: 'House', fuel_type: 'Biomass', count: 16 },
+                { building_type: 'House', fuel_type: 'WoodPellets', count: 5 },
+                { building_type: 'House', fuel_type: 'Anthracite', count: 4 },
+                { building_type: 'House', fuel_type: 'WoodChips', count: 3 },
+                { building_type: 'House', fuel_type: 'SmokelessCoal', count: 3 },
+                { building_type: 'House', fuel_type: 'Fuel', count: 3 },
+            ];
+
+            jest.spyOn(dashboardService, 'getFuelTypesByBuildingType').mockReturnValue(of(realWorldData));
+            fixture.detectChanges();
+
+            const chartData = component.chartData();
+            const barData = chartData[0] as PlotData;
+            const yLabels = barData.y as string[];
+
+            const uniqueLabels = new Set(yLabels);
+            expect(uniqueLabels.size).toBe(yLabels.length);
+        });
+
+        it('should aggregate counts when multiple fuel types map to the same label', () => {
+            // Both "Fuel" and "Other" map to label "Other" - counts should be summed
+            const dataWithDuplicateLabels: BackendFuelTypesByBuildingTypeResponse[] = [
+                { building_type: 'House', fuel_type: 'Other', count: 70 },
+                { building_type: 'House', fuel_type: 'Fuel', count: 3 },
+                { building_type: 'House', fuel_type: 'NaturalFuelGas', count: 100 },
+            ];
+
+            jest.spyOn(dashboardService, 'getFuelTypesByBuildingType').mockReturnValue(of(dataWithDuplicateLabels));
+            fixture.detectChanges();
+
+            const chartData = component.chartData();
+            const barData = chartData[0] as PlotData;
+            const yLabels = barData.y as string[];
+            const customdata = barData.customdata as number[];
+
+            // Should only have 2 labels: "Other" (aggregated) and "Natural Gas"
+            expect(yLabels.length).toBe(2);
+
+            // "Other" should have aggregated count of 70 + 3 = 73
+            const otherIndex = yLabels.indexOf('Other');
+            expect(customdata[otherIndex]).toBe(73);
+        });
+    });
 });

--- a/src/app/containers/dashboard/charts/building-fuel-chart/building-fuel-chart.component.ts
+++ b/src/app/containers/dashboard/charts/building-fuel-chart/building-fuel-chart.component.ts
@@ -49,13 +49,16 @@ export class BuildingFuelChartComponent extends BaseChartComponent {
             return [];
         }
 
-        const chartData = buildingData.map((item) => ({
-            label: this.getFuelTypeLabel(item.fuel_type),
-            value: item.count,
-        }));
+        // Aggregate counts by label (multiple fuel types may map to the same label)
+        const aggregatedByLabel: Record<string, number> = {};
+        for (const item of buildingData) {
+            const label = this.getFuelTypeLabel(item.fuel_type);
+            aggregatedByLabel[label] = (aggregatedByLabel[label] ?? 0) + item.count;
+        }
 
-        // smallest first, rendered bottom-to-top
-        return chartData.sort((a, b) => a.value - b.value);
+        return Object.entries(aggregatedByLabel)
+            .map(([label, value]) => ({ label, value }))
+            .toSorted((a, b) => a.value - b.value);
     });
 
     constructor() {


### PR DESCRIPTION
Fuel was mapping to Other, which is also returned so we ended up with duplicate labels on the chart causing issues.

## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Ordering is wrong on the fuel chart for Other

https://ndtp.atlassian.net/browse/DPAV-1955

## Description

Label mapping was creating duplicate labels, aggregate the values to avoid this.

## How Has This Been Tested?

Manually & unit test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
