### PR TITLE
feat(dpav-2420): added logic to show warnings to the climate data sections in the details panel

### DIFF
--- a/src/app/components/details-panel/details-panel.component.html
+++ b/src/app/components/details-panel/details-panel.component.html
@@ -1,6 +1,7 @@
 @let building = buildingDetails();
 @let expanded = resultsPanelCollapsed();
 @let indent = buildingSelection() ? 2 : 1;
+@let extremeWeatherWarningData = buildingExtremeWeatherSummaryData$ | async;
 
 @if (building) {
     <c477-info-panel [expanded]="indent === 1 || expanded" [indent]="indent">
@@ -8,7 +9,7 @@
             <div class="header">
                 <div class="panel-button">
                     <h2>{{ getAddressSegment(0) }} {{ getAddressSegment(1) }}</h2>
-                    <button mat-icon-button (click)="closePanel.emit()">
+                    <button mat-icon-button (click)="closeDetailsPanel()">
                         <mat-icon>close</mat-icon>
                     </button>
                 </div>
@@ -24,7 +25,7 @@
             </div>
 
             <div class="content">
-                <mat-tab-group [mat-stretch-tabs]="false">
+                <mat-tab-group [mat-stretch-tabs]="false" (selectedTabChange)="tabChanged($event)">
                     <mat-tab>
                         <ng-template mat-tab-label>
                             <span class="tab-label">Overview</span>
@@ -32,10 +33,31 @@
                         @let expired = epcExpired();
                         <ng-container [ngTemplateOutlet]="property" [ngTemplateOutletContext]="{ building: building, expired: expired }" />
                     </mat-tab>
-                    <mat-tab>
+                    <mat-tab id="moreInfo">
                         <ng-template mat-tab-label>
                             <div class="more-info-tab-label-container">
-                                <span class="tab-label more-info-tab-label">More info</span><mat-icon class="more-info-tab-label-icon">report</mat-icon>
+                                <span class="tab-label more-info-tab-label">More info</span>
+                                @if (
+                                    extremeWeatherWarningData?.affected_by_wind_driven_rain ||
+                                    extremeWeatherWarningData?.affected_by_icing_days ||
+                                    extremeWeatherWarningData?.affected_by_hot_summer_days
+                                ) {
+                                    <button matIconButton (click)="warnOverlayIsOpen = !warnOverlayIsOpen" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
+                                        <mat-icon class="more-info-tab-label-icon">warning_amber</mat-icon>
+                                    </button>
+                                    <ng-template
+                                        cdkConnectedOverlay
+                                        [cdkConnectedOverlayOrigin]="trigger"
+                                        [cdkConnectedOverlayOpen]="warnOverlayIsOpen"
+                                        (detach)="warnOverlayIsOpen = false"
+                                    >
+                                        <div class="more-info-tab-warning-popup">
+                                            <p class="more-info-tab-warning-popup-header">High exposure to exteme weather events</p>
+                                            <p>The property is within an area that is highly exposed to extreme weather events</p>
+                                            <button matButton (click)="warnOverlayIsOpen = false" class="more-info-tab-warning-popup-close">Close</button>
+                                        </div>
+                                    </ng-template>
+                                }
                             </div>
                         </ng-template>
                         <ng-container [ngTemplateOutlet]="moreinfo" [ngTemplateOutletContext]="{}" />
@@ -209,8 +231,11 @@
 
     <c477-more-info-section
         [buildingWindDrivenRainData]="buildingWindDrivenRainData$ | async"
+        [warnForWindDrivenRain]="extremeWeatherWarningData?.affected_by_wind_driven_rain || false"
         [buildingIcingDaysData]="buildingIcingDaysData$ | async"
+        [warnForIcingDays]="extremeWeatherWarningData?.affected_by_icing_days || false"
         [buildingHotSummerDaysData]="buildingHotSummerDaysData$ | async"
+        [warnForHotSummerDays]="extremeWeatherWarningData?.affected_by_hot_summer_days || false"
     ></c477-more-info-section>
 </ng-template>
 

--- a/src/app/components/details-panel/details-panel.component.scss
+++ b/src/app/components/details-panel/details-panel.component.scss
@@ -102,10 +102,10 @@
 
 .more-info-tab-label-container {
     display: flex;
-    gap: 5px;
+    gap: 2px;
 
     .more-info-tab-label-icon {
-        color: #7c7c7c;
+        color: #ffcf06;
     }
 }
 
@@ -120,11 +120,45 @@
     }
 }
 
-
 .more-info-subtext {
     color: #7c7c7c;
 }
 
 .more-info-divider {
     margin-bottom: 5px;
+}
+
+.more-info-tab-warning-popup {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+
+    width: 20rem;
+    padding: 1rem;
+    border-radius: 0.5rem;
+
+    background-color: var(--mat-sys-surface-container-low);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+
+    p {
+        margin: 0;
+    }
+
+    .more-info-tab-warning-popup-header {
+        font-weight: var(--mat-sys-label-large-weight);
+    }
+
+    .more-info-tab-warning-popup-close {
+        width: 1.5rem;
+        height: 1.5rem;
+        margin-top: 10px;
+        padding-left: 0;
+        border-radius: 9999px;
+
+        text-transform: none;
+
+        &:hover {
+            background-color: var(--mat-sys-surface-container-high);
+        }
+    }
 }

--- a/src/app/components/details-panel/details-panel.component.ts
+++ b/src/app/components/details-panel/details-panel.component.ts
@@ -1,3 +1,4 @@
+import { OverlayModule } from '@angular/cdk/overlay';
 import { AsyncPipe, DatePipe, NgClass, NgTemplateOutlet } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, Component, InputSignal, OutputEmitterRef, inject, input, output } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
@@ -6,7 +7,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatTabsModule } from '@angular/material/tabs';
+import { MatTabChangeEvent, MatTabsModule } from '@angular/material/tabs';
 import { DownloadWarningComponent } from '@components/download-warning/download-warning.component';
 import { LabelComponent } from '@components/label/label.component';
 import { MoreInfoSection } from '@components/more-info-section/more-info-section';
@@ -48,6 +49,7 @@ import { EMPTY, switchMap } from 'rxjs';
         InfoPanelComponent,
         MoreInfoSection,
         AsyncPipe,
+        OverlayModule,
     ],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     templateUrl: './details-panel.component.html',
@@ -79,6 +81,12 @@ export class DetailsPanelComponent {
     public roofMaterial: Record<string, string> = RoofMaterial;
     public roofShape: Record<string, string> = RoofShape;
     public solarPanelPresence: Record<string, string> = SolarPanelPresence;
+    public warnOverlayIsOpen: boolean = false;
+
+    public readonly buildingExtremeWeatherSummaryData$ = toObservable(this.buildingDetails).pipe(
+        takeUntilDestroyed(),
+        switchMap((b) => (b ? this.#climateDataService.getExtremeWeatherSummaryData(b.UPRN) : EMPTY)),
+    );
 
     public readonly buildingWindDrivenRainData$ = toObservable(this.buildingDetails).pipe(
         takeUntilDestroyed(),
@@ -147,6 +155,17 @@ export class DetailsPanelComponent {
         add('North West', building.RoofAspectAreaNorthwest);
         add('Unknown', building.RoofAspectAreaIndeterminable);
         return entries.join(', ');
+    }
+
+    public closeDetailsPanel(): void {
+        this.warnOverlayIsOpen = false;
+        this.closePanel.emit();
+    }
+
+    public tabChanged($event: MatTabChangeEvent): void {
+        if ($event.tab.id !== 'moreInfo') {
+            this.warnOverlayIsOpen = false;
+        }
     }
 }
 

--- a/src/app/components/hot-summer-days-section-item/hot-summer-days-section-item.html
+++ b/src/app/components/hot-summer-days-section-item/hot-summer-days-section-item.html
@@ -1,4 +1,4 @@
-<c477-more-info-section-item header="Hot summer days" subtitle="Within an area of many hot summer days">
+<c477-more-info-section-item header="Hot summer days" subtitle="Within an area of many hot summer days" [warn]="warn">
     @if (data) {
         <div class="container data-table">
             <dl>

--- a/src/app/components/hot-summer-days-section-item/hot-summer-days-section-item.ts
+++ b/src/app/components/hot-summer-days-section-item/hot-summer-days-section-item.ts
@@ -10,6 +10,7 @@ import { BuildingHotSummerDaysData } from '@core/services/climate-data.service';
 })
 export class HotSummerDaysSectionItem {
     @Input() public data: BuildingHotSummerDaysData | null = null;
+    @Input() public warn: boolean = false;
 }
 
 // SPDX-License-Identifier: Apache-2.0

--- a/src/app/components/icing-days-section-item/icing-days-section-item.html
+++ b/src/app/components/icing-days-section-item/icing-days-section-item.html
@@ -1,4 +1,4 @@
-<c477-more-info-section-item header="Icing days" subtitle="Within an area of many icing days">
+<c477-more-info-section-item header="Icing days" subtitle="Within an area of many icing days" [warn]="warn">
     @if (data) {
         <div class="container data-table">
             <dl>

--- a/src/app/components/icing-days-section-item/icing-days-section-item.ts
+++ b/src/app/components/icing-days-section-item/icing-days-section-item.ts
@@ -10,6 +10,7 @@ import { BuildingIcingDaysData } from '@core/services/climate-data.service';
 })
 export class IcingDaysSectionItem {
     @Input() public data: BuildingIcingDaysData | null = null;
+    @Input() public warn: boolean = false;
 }
 
 // SPDX-License-Identifier: Apache-2.0

--- a/src/app/components/more-info-section-item/more-info-section-item.html
+++ b/src/app/components/more-info-section-item/more-info-section-item.html
@@ -2,8 +2,13 @@
     <div class="section-item-container">
         <div (click)="sectionItem.toggle()" class="section-item-header-container">
             <div class="section-item-header">
-                <span [innerHTML]="header"></span
-                ><mat-icon data-testid="section-item-toggle-icon">{{ sectionItem.expanded ? 'arrow_drop_up' : 'arrow_drop_down' }}</mat-icon>
+                <div class="section-item-text">
+                    <span [innerHTML]="header"></span>
+                    @if (warn) {
+                        <mat-icon class="section-item-warning-icon">warning_amber</mat-icon>
+                    }
+                </div>
+                <mat-icon data-testid="section-item-toggle-icon">{{ sectionItem.expanded ? 'arrow_drop_up' : 'arrow_drop_down' }}</mat-icon>
             </div>
             @if (subtitle) {
                 <div>

--- a/src/app/components/more-info-section-item/more-info-section-item.scss
+++ b/src/app/components/more-info-section-item/more-info-section-item.scss
@@ -53,6 +53,12 @@
   margin-bottom: 5px;
 }
 
+.section-item-warning-icon {
+  margin-left: 5px;
+  color: #ffcf06;
+  vertical-align: middle;
+}
+
 // SPDX-License-Identifier: Apache-2.0
 // © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.

--- a/src/app/components/more-info-section-item/more-info-section-item.spec.ts
+++ b/src/app/components/more-info-section-item/more-info-section-item.spec.ts
@@ -47,4 +47,20 @@ describe('MoreInfoSectionItem', () => {
 
         expect(toggleIconElement.textContent.trim()).toBe('arrow_drop_up');
     });
+
+    it('should not create the warning icon when warn is false', () => {
+        const warningIconElement = fixture.debugElement.query(By.css('.section-item-warning-icon'));
+        expect(warningIconElement).toBeFalsy();
+    });
+
+    it('should create the warning icon when warn is true', async () => {
+        component.warn = true;
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const warningIconElement = fixture.debugElement.query(By.css('.section-item-warning-icon')).nativeElement;
+
+        expect(warningIconElement.textContent.trim()).toBe('warning_amber');
+    });
 });

--- a/src/app/components/more-info-section-item/more-info-section-item.ts
+++ b/src/app/components/more-info-section-item/more-info-section-item.ts
@@ -12,6 +12,7 @@ import { MatIconModule } from '@angular/material/icon';
 export class MoreInfoSectionItem {
     @Input() public header: string = '';
     @Input() public subtitle?: string;
+    @Input() public warn: boolean = false;
 }
 
 // SPDX-License-Identifier: Apache-2.0

--- a/src/app/components/more-info-section/more-info-section.html
+++ b/src/app/components/more-info-section/more-info-section.html
@@ -1,7 +1,7 @@
 <cdk-accordion>
-    <c477-wind-driven-rain-section-item [data]="buildingWindDrivenRainData"></c477-wind-driven-rain-section-item>
-    <c477-icing-days-section-item [data]="buildingIcingDaysData"></c477-icing-days-section-item>
-    <c477-hot-summer-days-section-item [data]="buildingHotSummerDaysData"></c477-hot-summer-days-section-item>
+    <c477-wind-driven-rain-section-item [data]="buildingWindDrivenRainData" [warn]="warnForWindDrivenRain"></c477-wind-driven-rain-section-item>
+    <c477-icing-days-section-item [data]="buildingIcingDaysData" [warn]="warnForIcingDays"></c477-icing-days-section-item>
+    <c477-hot-summer-days-section-item [data]="buildingHotSummerDaysData" [warn]="warnForHotSummerDays"></c477-hot-summer-days-section-item>
     <c477-hours-of-sunlight-section-item></c477-hours-of-sunlight-section-item>
     <c477-guidance-section-item></c477-guidance-section-item>
 </cdk-accordion>

--- a/src/app/components/more-info-section/more-info-section.ts
+++ b/src/app/components/more-info-section/more-info-section.ts
@@ -24,8 +24,11 @@ import { BuildingHotSummerDaysData, BuildingIcingDaysData, BuildingWindDrivenRai
 })
 export class MoreInfoSection {
     @Input() public buildingWindDrivenRainData: BuildingWindDrivenRainData | null = null;
+    @Input() public warnForWindDrivenRain: boolean = false;
     @Input() public buildingIcingDaysData: BuildingIcingDaysData | null = null;
+    @Input() public warnForIcingDays: boolean = false;
     @Input() public buildingHotSummerDaysData: BuildingHotSummerDaysData | null = null;
+    @Input() public warnForHotSummerDays: boolean = false;
 }
 
 // SPDX-License-Identifier: Apache-2.0

--- a/src/app/components/wind-driven-rain-section-item/wind-driven-rain-section-item.html
+++ b/src/app/components/wind-driven-rain-section-item/wind-driven-rain-section-item.html
@@ -1,4 +1,4 @@
-<c477-more-info-section-item header="Wind-driven rain - <em>4&deg;C warming</em>" subtitle="Within an area of high wind-driven rain">
+<c477-more-info-section-item header="Wind-driven rain - <em>4&deg;C warming</em>" subtitle="Within an area of high wind-driven rain" [warn]="warn">
     @if (data) {
         <div class="container data-table" data-testid="4-degrees-table">
             <dl>
@@ -24,7 +24,7 @@
         </div>
     }
 </c477-more-info-section-item>
-<c477-more-info-section-item header="Wind-driven rain - <em>2&deg;C warming</em>" subtitle="Within an area of high wind-driven rain">
+<c477-more-info-section-item header="Wind-driven rain - <em>2&deg;C warming</em>" subtitle="Within an area of high wind-driven rain" [warn]="warn">
     @if (data) {
         <div class="container data-table" data-testid="2-degrees-table">
             <dl>

--- a/src/app/components/wind-driven-rain-section-item/wind-driven-rain-section-item.ts
+++ b/src/app/components/wind-driven-rain-section-item/wind-driven-rain-section-item.ts
@@ -10,6 +10,7 @@ import { BuildingWindDrivenRainData } from '@core/services/climate-data.service'
 })
 export class WindDrivenRainSectionItem {
     @Input() public data: BuildingWindDrivenRainData | null = null;
+    @Input() public warn: boolean = false;
 }
 
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[DPAV-2420](https://ndtp.atlassian.net/browse/DPAV-2420)

## Description
<!--- Describe your changes in detail -->
- Added a method to fetch the extreme weather summary from the API
- Added a way to pass warnings from the details panel to the more info section items
- Added tests to display a warning icon when a warning is present for the more info section item
- Added methods to handle closing of the popup when the panel is closed or the tab is changed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working as expected

## Screenshots (if appropriate):
<img width="571" height="691" alt="image" src="https://github.com/user-attachments/assets/7fd88890-f8fa-4275-9ab2-88b09762969b" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
