### PR TITLE
feat(dpav-2499): deprivation charts for dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 ## Unreleased
 
 - [DPAV-2487]: added high deprivation layer and associated popover
+- [DPAV-2499]: added deprivation charts for national + area views
 
 ## [0.95.1] - 2026-01-22
 

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.html
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.html
@@ -7,7 +7,43 @@
     @if (loading() || error()) {
         <c477-chart-placeholder [error]="error()" [onRetry]="retry.bind(this)" />
     } @else {
-        <plotly-plot [data]="chartData()" [layout]="chartLayout()" [config]="chartConfig"></plotly-plot>
+        <div class="national-histograms">
+            @for (row of histogramRows(); track row.key) {
+                <div class="histogram-row">
+                    <p class="histogram-title">
+                        <strong>{{ formatCount(row.count) }} households ({{ formatPercentage(row.value) }}) {{ row.statement }}</strong>
+                        @if (row.context) {
+                            <small>{{ row.context }}</small>
+                        }
+                    </p>
+                    @if (row.nationalAverage !== undefined) {
+                        <p class="national-average">National average {{ formatPercentage(row.nationalAverage) }}</p>
+                    }
+                    <div class="histogram deprivation-histogram">
+                        <div class="scale-wrapper">
+                            <div class="scale">
+                                @for (color of histogramColors; track color) {
+                                    <span class="scale-segment" [style.background-color]="color"></span>
+                                }
+                            </div>
+                            <div class="scale-marker area-marker" [style.left.%]="getMarkerPosition(row.value, row.min, row.max)" aria-hidden="true"></div>
+                            @if (row.nationalAverage !== undefined) {
+                                <div
+                                    class="scale-marker national-marker"
+                                    [style.left.%]="getMarkerPosition(row.nationalAverage, row.min, row.max)"
+                                    aria-hidden="true"
+                                ></div>
+                            }
+                        </div>
+                        <div class="stage-labels">
+                            @for (stage of getStageStops(row.min, row.max); track $index) {
+                                <span class="stage-label" [style.left.%]="$index * 20">{{ formatPercentage(stage) }}</span>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
     }
 </div>
 

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.html
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.html
@@ -1,0 +1,16 @@
+<div class="widget-header">
+    <div class="widget-title">
+        <span>Percentage of homes that experience deprivation</span>
+    </div>
+</div>
+<div class="chart-wrapper">
+    @if (loading() || error()) {
+        <c477-chart-placeholder [error]="error()" [onRetry]="retry.bind(this)" />
+    } @else {
+        <plotly-plot [data]="chartData()" [layout]="chartLayout()" [config]="chartConfig"></plotly-plot>
+    }
+</div>
+
+<!-- SPDX-License-Identifier: Apache-2.0
+© Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+and is legally attributed to the Department for Business and Trade (UK) as the governing entity. -->

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.scss
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.scss
@@ -1,0 +1,1 @@
+@import '../chart-shared';

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.scss
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.scss
@@ -1,1 +1,141 @@
 @import '../chart-shared';
+
+.national-histograms {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-self: stretch;
+
+    width: 100%;
+    padding: 0.25rem 0 0;
+}
+
+.histogram-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.histogram-title {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.3;
+
+    small {
+        margin-left: 0.3rem;
+        font-size: 0.82rem;
+        font-weight: 400;
+    }
+
+    span {
+        margin-left: 0.35rem;
+        font-size: 0.85rem;
+        font-weight: 400;
+    }
+
+}
+
+.national-average {
+    margin: 0;
+
+    font-size: 0.85rem;
+    font-weight: 400;
+    line-height: 1.2;
+    color: #000000;
+}
+
+.deprivation-histogram {
+    padding-top: 1.15rem;
+    padding-bottom: 0.35rem;
+
+    .scale-wrapper {
+        position: relative;
+    }
+
+    .scale {
+        display: flex;
+        gap: 0;
+    }
+
+    .scale-segment {
+        display: block;
+        flex: 1;
+        height: 0.8rem;
+        border-radius: 0;
+    }
+
+    .scale-segment:first-child {
+        border-radius: 2px 0 0 2px;
+    }
+
+    .scale-segment:last-child {
+        border-radius: 0 2px 2px 0;
+    }
+
+    .scale-marker {
+        pointer-events: none;
+
+        position: absolute;
+        transform: translateX(-50%);
+
+        width: 1.2rem;
+        height: 1.2rem;
+    }
+
+    .area-marker {
+        top: -1.05rem;
+
+        &::before {
+            content: '';
+
+            position: absolute;
+            inset: 0;
+
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpolygon points='50,90 5,12 95,12' fill='white' stroke='%23000000' stroke-width='10' stroke-linejoin='round'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: contain;
+        }
+    }
+
+    .national-marker {
+        top: -0.55rem;
+        width: 0.8rem;
+        height: 0.8rem;
+
+        &::before {
+            content: '';
+
+            position: absolute;
+            inset: 0;
+
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpolygon points='50,90 5,12 95,12' fill='%2318376b' stroke='%2318376b' stroke-width='8' stroke-linejoin='round'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: contain;
+        }
+    }
+
+    .stage-labels {
+        position: relative;
+        height: 1rem;
+        margin-top: 0.55rem;
+    }
+
+    .stage-label {
+        position: absolute;
+        transform: translateX(-50%);
+
+        font-size: 0.75rem;
+        line-height: 1.15;
+        white-space: nowrap;
+    }
+
+    .stage-label:first-child {
+        transform: translateX(0);
+    }
+
+    .stage-label:last-child {
+        transform: translateX(-100%);
+    }
+}

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.spec.ts
@@ -1,0 +1,164 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AreaFilter } from '@core/models/area-filter.model';
+import { BackendBuildingsByDeprivationDimensionResponse, DashboardService } from '@core/services/dashboard.service';
+import { RUNTIME_CONFIGURATION } from '@core/tokens/runtime-configuration.token';
+import { Data, PlotData } from 'plotly.js-dist-min';
+import { of } from 'rxjs';
+import { getPlotlyModuleProviders } from '../plotly.mock';
+import { DeprivationDimensionChartComponent } from './deprivation-dimension-chart.component';
+
+const mockRuntimeConfig = {};
+
+const mockApiResponse: BackendBuildingsByDeprivationDimensionResponse = {
+    dep_0_pct: 52.3,
+    dep_1_pct: 27.4,
+    dep_2_pct: 12.8,
+    dep_3_pct: 5.6,
+    dep_4_pct: 1.9,
+};
+
+const mockFilteredApiResponse: BackendBuildingsByDeprivationDimensionResponse = {
+    dep_0_pct: 48.4,
+    dep_1_pct: 30.2,
+    dep_2_pct: 13.5,
+    dep_3_pct: 6.0,
+    dep_4_pct: 1.9,
+};
+
+describe('DeprivationDimensionChartComponent', () => {
+    let component: DeprivationDimensionChartComponent;
+    let fixture: ComponentFixture<DeprivationDimensionChartComponent>;
+    let dashboardService: DashboardService;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [DeprivationDimensionChartComponent],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                ...getPlotlyModuleProviders(),
+                { provide: RUNTIME_CONFIGURATION, useValue: mockRuntimeConfig },
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(DeprivationDimensionChartComponent);
+        component = fixture.componentInstance;
+        dashboardService = TestBed.inject(DashboardService);
+    });
+
+    it('should create the component', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should initialize with loading state', () => {
+        expect(component.loading()).toBe(true);
+        expect(component.chartData()).toEqual([]);
+    });
+
+    it('should load deprivation data', () => {
+        jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockReturnValue(of(mockApiResponse));
+
+        fixture.detectChanges();
+
+        expect(dashboardService.getBuildingsByDeprivationDimension).toHaveBeenCalledWith();
+        expect(component.loading()).toBe(false);
+    });
+
+    it('should load national and filtered data when areaFilter is provided', () => {
+        const mockAreaFilter: AreaFilter = {
+            mode: 'polygon',
+            polygon: {
+                type: 'Polygon',
+                coordinates: [
+                    [
+                        [0, 0],
+                        [1, 0],
+                        [1, 1],
+                        [0, 1],
+                        [0, 0],
+                    ],
+                ],
+            },
+        };
+
+        const spy = jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockImplementation((filter?: AreaFilter) => {
+            return of(filter ? mockFilteredApiResponse : mockApiResponse);
+        });
+
+        fixture.componentRef.setInput('areaFilter', mockAreaFilter);
+        fixture.detectChanges();
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenNthCalledWith(1);
+        expect(spy).toHaveBeenNthCalledWith(2, mockAreaFilter);
+        expect(component.loading()).toBe(false);
+    });
+
+    describe('chart data transformation', () => {
+        beforeEach(() => {
+            jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockReturnValue(of(mockApiResponse));
+            fixture.detectChanges();
+        });
+
+        it('should create one bar series', () => {
+            const chartData: Data[] = component.chartData();
+            expect(chartData.length).toBe(1);
+            expect(chartData[0].type).toBe('bar');
+        });
+
+        it('should map data to deprivation dimension labels in order', () => {
+            const chartData: Data[] = component.chartData();
+            const plotData: PlotData = chartData[0] as PlotData;
+
+            expect(plotData.x).toEqual(['0D', '1D', '2D', '3D', '4D']);
+            expect(plotData.y).toEqual([52.3, 27.4, 12.8, 5.6, 1.9]);
+        });
+
+        it('should format hover as percentage', () => {
+            const chartData: Data[] = component.chartData();
+            const plotData: PlotData = chartData[0] as PlotData;
+            expect(plotData.hovertemplate).toBe('%{y:.1f}%<extra></extra>');
+        });
+    });
+
+    it('should create comparison mode chart in area/polygon view', () => {
+        const mockAreaFilter: AreaFilter = {
+            mode: 'polygon',
+            polygon: {
+                type: 'Polygon',
+                coordinates: [
+                    [
+                        [0, 0],
+                        [1, 0],
+                        [1, 1],
+                        [0, 1],
+                        [0, 0],
+                    ],
+                ],
+            },
+        };
+
+        jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockImplementation((filter?: AreaFilter) => {
+            return of(filter ? mockFilteredApiResponse : mockApiResponse);
+        });
+
+        fixture.componentRef.setInput('areaFilter', mockAreaFilter);
+        fixture.detectChanges();
+
+        const chartData: Data[] = component.chartData();
+        expect(chartData.length).toBe(2);
+        expect(chartData[0].name).toBe('Area average');
+        expect(chartData[1].name).toBe('National average');
+
+        const filteredPlotData: PlotData = chartData[0] as PlotData;
+        const nationalPlotData: PlotData = chartData[1] as PlotData;
+        expect(filteredPlotData.y).toEqual([48.4, 30.2, 13.5, 6.0, 1.9]);
+        expect(nationalPlotData.y).toEqual([52.3, 27.4, 12.8, 5.6, 1.9]);
+    });
+});
+
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.spec.ts
@@ -4,27 +4,35 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AreaFilter } from '@core/models/area-filter.model';
 import { BackendBuildingsByDeprivationDimensionResponse, DashboardService } from '@core/services/dashboard.service';
 import { RUNTIME_CONFIGURATION } from '@core/tokens/runtime-configuration.token';
-import { Data, PlotData } from 'plotly.js-dist-min';
 import { of } from 'rxjs';
-import { getPlotlyModuleProviders } from '../plotly.mock';
 import { DeprivationDimensionChartComponent } from './deprivation-dimension-chart.component';
 
 const mockRuntimeConfig = {};
 
 const mockApiResponse: BackendBuildingsByDeprivationDimensionResponse = {
-    dep_0_pct: 52.3,
-    dep_1_pct: 27.4,
-    dep_2_pct: 12.8,
-    dep_3_pct: 5.6,
-    dep_4_pct: 1.9,
+    dep_3_pct: null,
+    dep_4_pct: null,
+    dep_3_count: 1632876,
+    dep_4_count: 603221,
+    unfiltered_dep_3_pct: 8.21,
+    unfiltered_dep_4_pct: 3.28,
+    min_dep_3_pct: 0.0,
+    max_dep_3_pct: 27.64,
+    min_dep_4_pct: 0.0,
+    max_dep_4_pct: 18.92,
 };
 
 const mockFilteredApiResponse: BackendBuildingsByDeprivationDimensionResponse = {
-    dep_0_pct: 48.4,
-    dep_1_pct: 30.2,
-    dep_2_pct: 13.5,
-    dep_3_pct: 6.0,
-    dep_4_pct: 1.9,
+    dep_3_pct: 9.47,
+    dep_4_pct: 4.03,
+    dep_3_count: 128442,
+    dep_4_count: 54631,
+    unfiltered_dep_3_pct: 8.21,
+    unfiltered_dep_4_pct: 3.28,
+    min_dep_3_pct: 1.12,
+    max_dep_3_pct: 22.85,
+    min_dep_4_pct: 0.24,
+    max_dep_4_pct: 14.73,
 };
 
 describe('DeprivationDimensionChartComponent', () => {
@@ -35,12 +43,7 @@ describe('DeprivationDimensionChartComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [DeprivationDimensionChartComponent],
-            providers: [
-                provideHttpClient(),
-                provideHttpClientTesting(),
-                ...getPlotlyModuleProviders(),
-                { provide: RUNTIME_CONFIGURATION, useValue: mockRuntimeConfig },
-            ],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: RUNTIME_CONFIGURATION, useValue: mockRuntimeConfig }],
         }).compileComponents();
 
         fixture = TestBed.createComponent(DeprivationDimensionChartComponent);
@@ -54,7 +57,7 @@ describe('DeprivationDimensionChartComponent', () => {
 
     it('should initialize with loading state', () => {
         expect(component.loading()).toBe(true);
-        expect(component.chartData()).toEqual([]);
+        expect(component.histogramRows()).toEqual([]);
     });
 
     it('should load deprivation data', () => {
@@ -62,11 +65,11 @@ describe('DeprivationDimensionChartComponent', () => {
 
         fixture.detectChanges();
 
-        expect(dashboardService.getBuildingsByDeprivationDimension).toHaveBeenCalledWith();
+        expect(dashboardService.getBuildingsByDeprivationDimension).toHaveBeenCalledWith(undefined);
         expect(component.loading()).toBe(false);
     });
 
-    it('should load national and filtered data when areaFilter is provided', () => {
+    it('should load filtered data with a single API call when areaFilter is provided', () => {
         const mockAreaFilter: AreaFilter = {
             mode: 'polygon',
             polygon: {
@@ -83,47 +86,45 @@ describe('DeprivationDimensionChartComponent', () => {
             },
         };
 
-        const spy = jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockImplementation((filter?: AreaFilter) => {
-            return of(filter ? mockFilteredApiResponse : mockApiResponse);
-        });
+        const spy = jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockReturnValue(of(mockFilteredApiResponse));
 
         fixture.componentRef.setInput('areaFilter', mockAreaFilter);
         fixture.detectChanges();
 
-        expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).toHaveBeenNthCalledWith(1);
-        expect(spy).toHaveBeenNthCalledWith(2, mockAreaFilter);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(mockAreaFilter);
         expect(component.loading()).toBe(false);
     });
 
-    describe('chart data transformation', () => {
-        beforeEach(() => {
-            jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockReturnValue(of(mockApiResponse));
-            fixture.detectChanges();
-        });
+    it('should use unfiltered values in national mode when dep values are null', () => {
+        jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockReturnValue(of(mockApiResponse));
+        fixture.detectChanges();
 
-        it('should create one bar series', () => {
-            const chartData: Data[] = component.chartData();
-            expect(chartData.length).toBe(1);
-            expect(chartData[0].type).toBe('bar');
-        });
-
-        it('should map data to deprivation dimension labels in order', () => {
-            const chartData: Data[] = component.chartData();
-            const plotData: PlotData = chartData[0] as PlotData;
-
-            expect(plotData.x).toEqual(['0D', '1D', '2D', '3D', '4D']);
-            expect(plotData.y).toEqual([52.3, 27.4, 12.8, 5.6, 1.9]);
-        });
-
-        it('should format hover as percentage', () => {
-            const chartData: Data[] = component.chartData();
-            const plotData: PlotData = chartData[0] as PlotData;
-            expect(plotData.hovertemplate).toBe('%{y:.1f}%<extra></extra>');
-        });
+        expect(component.histogramRows()).toEqual([
+            {
+                key: 'dep4',
+                count: 603221,
+                value: 3.28,
+                statement: 'are highly deprived',
+                context: '(deprived in four dimensions)',
+                min: 0,
+                max: 18.92,
+                nationalAverage: undefined,
+            },
+            {
+                key: 'dep3',
+                count: 1632876,
+                value: 8.21,
+                statement: 'are deprived in three dimensions',
+                min: 0,
+                max: 27.64,
+                nationalAverage: undefined,
+            },
+        ]);
+        expect(component.isNationalView()).toBe(true);
     });
 
-    it('should create comparison mode chart in area/polygon view', () => {
+    it('should include national averages in area/polygon mode histogram rows', () => {
         const mockAreaFilter: AreaFilter = {
             mode: 'polygon',
             polygon: {
@@ -140,22 +141,32 @@ describe('DeprivationDimensionChartComponent', () => {
             },
         };
 
-        jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockImplementation((filter?: AreaFilter) => {
-            return of(filter ? mockFilteredApiResponse : mockApiResponse);
-        });
-
+        jest.spyOn(dashboardService, 'getBuildingsByDeprivationDimension').mockReturnValue(of(mockFilteredApiResponse));
         fixture.componentRef.setInput('areaFilter', mockAreaFilter);
         fixture.detectChanges();
 
-        const chartData: Data[] = component.chartData();
-        expect(chartData.length).toBe(2);
-        expect(chartData[0].name).toBe('Area average');
-        expect(chartData[1].name).toBe('National average');
-
-        const filteredPlotData: PlotData = chartData[0] as PlotData;
-        const nationalPlotData: PlotData = chartData[1] as PlotData;
-        expect(filteredPlotData.y).toEqual([48.4, 30.2, 13.5, 6.0, 1.9]);
-        expect(nationalPlotData.y).toEqual([52.3, 27.4, 12.8, 5.6, 1.9]);
+        expect(component.histogramRows()).toEqual([
+            {
+                key: 'dep4',
+                count: 54631,
+                value: 4.03,
+                statement: 'are highly deprived',
+                context: '(deprived in four dimensions)',
+                min: 0.24,
+                max: 14.73,
+                nationalAverage: 3.28,
+            },
+            {
+                key: 'dep3',
+                count: 128442,
+                value: 9.47,
+                statement: 'are deprived in three dimensions',
+                min: 1.12,
+                max: 22.85,
+                nationalAverage: 8.21,
+            },
+        ]);
+        expect(component.isNationalView()).toBe(false);
     });
 });
 

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.ts
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.ts
@@ -1,145 +1,79 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, effect, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
 import { BackendBuildingsByDeprivationDimensionResponse } from '@core/services/dashboard.service';
-import { PlotlyModule } from 'angular-plotly.js';
-import { Data, Layout } from 'plotly.js-dist-min';
-import { forkJoin } from 'rxjs';
 import { BaseChartComponent } from '../base-chart.component';
 import { ChartPlaceholderComponent } from '../shared/chart-placeholder.component';
 
 @Component({
     selector: 'c477-deprivation-dimension-chart',
-    imports: [CommonModule, PlotlyModule, ChartPlaceholderComponent],
+    imports: [CommonModule, ChartPlaceholderComponent],
     templateUrl: './deprivation-dimension-chart.component.html',
     styleUrl: './deprivation-dimension-chart.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DeprivationDimensionChartComponent extends BaseChartComponent {
-    public chartData = signal<Data[]>([]);
-    public chartLayout = signal<Partial<Layout>>({});
+    public readonly histogramColors = ['#CDE594', '#80C6A3', '#1F9EB7', '#186290', '#080C54'];
 
-    private readonly deprivationDimensionData = signal<{
-        national: BackendBuildingsByDeprivationDimensionResponse;
-        filtered?: BackendBuildingsByDeprivationDimensionResponse;
-    } | null>(null);
+    private readonly deprivationDimensionData = signal<BackendBuildingsByDeprivationDimensionResponse | null>(null);
+    public readonly isNationalView = computed(() => !this.areaFilter);
+    public readonly histogramRows = computed(() => {
+        const response = this.deprivationDimensionData();
+        if (!response) {
+            return [];
+        }
 
-    constructor() {
-        super();
-        effect(() => {
-            const deprivationDimensionData = this.deprivationDimensionData();
-            if (!deprivationDimensionData) {
-                return;
-            }
+        const resolveValue = (value: number | null, fallback: number): number => (typeof value === 'number' ? value : fallback);
+        const isFilteredMode = !this.isNationalView();
 
-            const built = this.buildChart(deprivationDimensionData);
-            this.chartData.set(built.data);
-            this.chartLayout.set(built.layout);
-        });
-    }
+        return [
+            {
+                key: 'dep4',
+                count: response.dep_4_count,
+                value: resolveValue(response.dep_4_pct, response.unfiltered_dep_4_pct),
+                statement: 'are highly deprived',
+                context: '(deprived in four dimensions)',
+                nationalAverage: isFilteredMode ? response.unfiltered_dep_4_pct : undefined,
+                min: response.min_dep_4_pct,
+                max: response.max_dep_4_pct,
+            },
+            {
+                key: 'dep3',
+                count: response.dep_3_count,
+                value: resolveValue(response.dep_3_pct, response.unfiltered_dep_3_pct),
+                statement: 'are deprived in three dimensions',
+                nationalAverage: isFilteredMode ? response.unfiltered_dep_3_pct : undefined,
+                min: response.min_dep_3_pct,
+                max: response.max_dep_3_pct,
+            },
+        ];
+    });
 
     protected override loadData(): void {
-        if (this.areaFilter) {
-            this.subscribe(
-                forkJoin({
-                    national: this.dashboardService.getBuildingsByDeprivationDimension(),
-                    filtered: this.dashboardService.getBuildingsByDeprivationDimension(this.areaFilter),
-                }),
-                (data) => {
-                    this.deprivationDimensionData.set(data);
-                },
-            );
-            return;
-        }
-
-        this.subscribe(this.dashboardService.getBuildingsByDeprivationDimension(), (data) => {
-            this.deprivationDimensionData.set({ national: data });
+        this.subscribe(this.dashboardService.getBuildingsByDeprivationDimension(this.areaFilter), (data) => {
+            this.deprivationDimensionData.set(data);
         });
     }
 
-    private buildChart(deprivationDimensionData: {
-        national: BackendBuildingsByDeprivationDimensionResponse;
-        filtered?: BackendBuildingsByDeprivationDimensionResponse;
-    }): { data: Data[]; layout: Partial<Layout> } {
-        const labels = ['0D', '1D', '2D', '3D', '4D'];
-        const hasFilteredData = !!deprivationDimensionData.filtered;
-
-        const mapValues = (values: BackendBuildingsByDeprivationDimensionResponse): number[] => [
-            values.dep_0_pct,
-            values.dep_1_pct,
-            values.dep_2_pct,
-            values.dep_3_pct,
-            values.dep_4_pct,
-        ];
-
-        const data: Data[] = [];
-        if (deprivationDimensionData.filtered) {
-            data.push({
-                type: 'bar',
-                name: 'Area average',
-                x: labels,
-                y: mapValues(deprivationDimensionData.filtered),
-                marker: { color: '#3670b3' },
-                hoverlabel: this.chartService.commonHoverStyle,
-                hovertemplate: '%{y:.1f}%<extra></extra>',
-            });
+    public getMarkerPosition(value: number, min: number, max: number): number {
+        if (max <= min) {
+            return 0;
         }
 
-        data.push({
-            type: 'bar',
-            name: 'National average',
-            x: labels,
-            y: mapValues(deprivationDimensionData.national),
-            marker: { color: hasFilteredData ? '#002244' : '#3670b3' },
-            hoverlabel: this.chartService.commonHoverStyle,
-            hovertemplate: '%{y:.1f}%<extra></extra>',
-        });
+        const percentage = ((value - min) / (max - min)) * 100;
+        return Math.max(0, Math.min(100, percentage));
+    }
 
-        const layout: Partial<Layout> = {
-            margin: { l: 20, r: 40, t: 20, b: hasFilteredData ? 140 : 95 },
-            xaxis: {
-                title: { text: '' },
-                tickangle: 0,
-                tickfont: { size: 11, color: '#999' },
-                automargin: true,
-            },
-            yaxis: {
-                title: { text: '' },
-                ticksuffix: '%',
-                showgrid: false,
-                side: 'right',
-                tickfont: { size: 11, color: '#999' },
-                linewidth: 0,
-            },
-            font: this.chartService.commonFont,
-            height: 250,
-            plot_bgcolor: 'white',
-            paper_bgcolor: 'white',
-            showlegend: hasFilteredData,
-            legend: {
-                orientation: 'v',
-                x: 0,
-                y: -0.26,
-                xanchor: 'left',
-                yanchor: 'top',
-            },
-            barmode: hasFilteredData ? 'group' : undefined,
-            annotations: [
-                {
-                    text: '<b>0D</b> = Not deprived | <b>1D</b> = 1 dimension | <b>2D</b> = 2 dimensions | <b>3D</b> = 3 dimensions | <b>4D</b> = 4 dimensions',
-                    showarrow: false,
-                    xref: 'paper',
-                    yref: 'paper',
-                    x: 0,
-                    y: hasFilteredData ? -0.68 : -0.35,
-                    xanchor: 'left',
-                    yanchor: 'top',
-                    font: { size: 11, color: '#333' },
-                    align: 'left',
-                },
-            ],
-        };
+    public getStageStops(min: number, max: number): number[] {
+        const stops = [0, 0.2, 0.4, 0.6, 0.8, 1];
+        return stops.map((stop) => min + (max - min) * stop);
+    }
 
-        return { data, layout };
+    public formatPercentage(value: number): string {
+        return `${value.toFixed(1)}%`;
+    }
+
+    public formatCount(value: number): string {
+        return value.toLocaleString('en-GB');
     }
 }
 

--- a/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.ts
+++ b/src/app/containers/dashboard/charts/deprivation-dimension-chart/deprivation-dimension-chart.component.ts
@@ -1,0 +1,148 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, effect, signal } from '@angular/core';
+import { BackendBuildingsByDeprivationDimensionResponse } from '@core/services/dashboard.service';
+import { PlotlyModule } from 'angular-plotly.js';
+import { Data, Layout } from 'plotly.js-dist-min';
+import { forkJoin } from 'rxjs';
+import { BaseChartComponent } from '../base-chart.component';
+import { ChartPlaceholderComponent } from '../shared/chart-placeholder.component';
+
+@Component({
+    selector: 'c477-deprivation-dimension-chart',
+    imports: [CommonModule, PlotlyModule, ChartPlaceholderComponent],
+    templateUrl: './deprivation-dimension-chart.component.html',
+    styleUrl: './deprivation-dimension-chart.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DeprivationDimensionChartComponent extends BaseChartComponent {
+    public chartData = signal<Data[]>([]);
+    public chartLayout = signal<Partial<Layout>>({});
+
+    private readonly deprivationDimensionData = signal<{
+        national: BackendBuildingsByDeprivationDimensionResponse;
+        filtered?: BackendBuildingsByDeprivationDimensionResponse;
+    } | null>(null);
+
+    constructor() {
+        super();
+        effect(() => {
+            const deprivationDimensionData = this.deprivationDimensionData();
+            if (!deprivationDimensionData) {
+                return;
+            }
+
+            const built = this.buildChart(deprivationDimensionData);
+            this.chartData.set(built.data);
+            this.chartLayout.set(built.layout);
+        });
+    }
+
+    protected override loadData(): void {
+        if (this.areaFilter) {
+            this.subscribe(
+                forkJoin({
+                    national: this.dashboardService.getBuildingsByDeprivationDimension(),
+                    filtered: this.dashboardService.getBuildingsByDeprivationDimension(this.areaFilter),
+                }),
+                (data) => {
+                    this.deprivationDimensionData.set(data);
+                },
+            );
+            return;
+        }
+
+        this.subscribe(this.dashboardService.getBuildingsByDeprivationDimension(), (data) => {
+            this.deprivationDimensionData.set({ national: data });
+        });
+    }
+
+    private buildChart(deprivationDimensionData: {
+        national: BackendBuildingsByDeprivationDimensionResponse;
+        filtered?: BackendBuildingsByDeprivationDimensionResponse;
+    }): { data: Data[]; layout: Partial<Layout> } {
+        const labels = ['0D', '1D', '2D', '3D', '4D'];
+        const hasFilteredData = !!deprivationDimensionData.filtered;
+
+        const mapValues = (values: BackendBuildingsByDeprivationDimensionResponse): number[] => [
+            values.dep_0_pct,
+            values.dep_1_pct,
+            values.dep_2_pct,
+            values.dep_3_pct,
+            values.dep_4_pct,
+        ];
+
+        const data: Data[] = [];
+        if (deprivationDimensionData.filtered) {
+            data.push({
+                type: 'bar',
+                name: 'Area average',
+                x: labels,
+                y: mapValues(deprivationDimensionData.filtered),
+                marker: { color: '#3670b3' },
+                hoverlabel: this.chartService.commonHoverStyle,
+                hovertemplate: '%{y:.1f}%<extra></extra>',
+            });
+        }
+
+        data.push({
+            type: 'bar',
+            name: 'National average',
+            x: labels,
+            y: mapValues(deprivationDimensionData.national),
+            marker: { color: hasFilteredData ? '#002244' : '#3670b3' },
+            hoverlabel: this.chartService.commonHoverStyle,
+            hovertemplate: '%{y:.1f}%<extra></extra>',
+        });
+
+        const layout: Partial<Layout> = {
+            margin: { l: 20, r: 40, t: 20, b: hasFilteredData ? 140 : 95 },
+            xaxis: {
+                title: { text: '' },
+                tickangle: 0,
+                tickfont: { size: 11, color: '#999' },
+                automargin: true,
+            },
+            yaxis: {
+                title: { text: '' },
+                ticksuffix: '%',
+                showgrid: false,
+                side: 'right',
+                tickfont: { size: 11, color: '#999' },
+                linewidth: 0,
+            },
+            font: this.chartService.commonFont,
+            height: 250,
+            plot_bgcolor: 'white',
+            paper_bgcolor: 'white',
+            showlegend: hasFilteredData,
+            legend: {
+                orientation: 'v',
+                x: 0,
+                y: -0.26,
+                xanchor: 'left',
+                yanchor: 'top',
+            },
+            barmode: hasFilteredData ? 'group' : undefined,
+            annotations: [
+                {
+                    text: '<b>0D</b> = Not deprived | <b>1D</b> = 1 dimension | <b>2D</b> = 2 dimensions | <b>3D</b> = 3 dimensions | <b>4D</b> = 4 dimensions',
+                    showarrow: false,
+                    xref: 'paper',
+                    yref: 'paper',
+                    x: 0,
+                    y: hasFilteredData ? -0.68 : -0.35,
+                    xanchor: 'left',
+                    yanchor: 'top',
+                    font: { size: 11, color: '#333' },
+                    align: 'left',
+                },
+            ],
+        };
+
+        return { data, layout };
+    }
+}
+
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.

--- a/src/app/containers/dashboard/dashboard-page.component.html
+++ b/src/app/containers/dashboard/dashboard-page.component.html
@@ -81,6 +81,10 @@
                 <c477-epc-by-area-chart [areaFilter]="areaFilter()"></c477-epc-by-area-chart>
             </section>
         }
+
+        <section class="widget-card">
+            <c477-deprivation-dimension-chart [areaFilter]="areaFilter()"></c477-deprivation-dimension-chart>
+        </section>
     </div>
 </div>
 

--- a/src/app/containers/dashboard/dashboard-page.component.ts
+++ b/src/app/containers/dashboard/dashboard-page.component.ts
@@ -8,6 +8,7 @@ import { AreaFilter } from '../../core/models/area-filter.model';
 import { DashboardType } from './chart.service';
 import { BuildingFuelChartComponent } from './charts/building-fuel-chart/building-fuel-chart.component';
 import { CharacteristicsChartComponent } from './charts/characteristics-chart/characteristics-chart.component';
+import { DeprivationDimensionChartComponent } from './charts/deprivation-dimension-chart/deprivation-dimension-chart.component';
 import { EpcByAreaChartComponent } from './charts/epc-by-area-chart/epc-by-area-chart.component';
 import { EpcByFeatureChartComponent } from './charts/epc-by-feature-chart/epc-by-feature-chart.component';
 import { EpcRatingsOvertimeChartComponent } from './charts/epc-ratings-over-time-chart/epc-ratings-over-time-chart.component';
@@ -31,6 +32,7 @@ const AREA_FILTER_STORAGE_KEY = 'dashboard.areaFilter';
         OverallEpcChartComponent,
         EpcByAreaChartComponent,
         CharacteristicsChartComponent,
+        DeprivationDimensionChartComponent,
         SapTimelineChartComponent,
         EpcRatingsOvertimeChartComponent,
         BuildingFuelChartComponent,

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -88,11 +88,16 @@ export interface BackendNumberOfInDateAndExpiredEpcsResponse {
 }
 
 export interface BackendBuildingsByDeprivationDimensionResponse {
-    dep_0_pct: number;
-    dep_1_pct: number;
-    dep_2_pct: number;
-    dep_3_pct: number;
-    dep_4_pct: number;
+    dep_3_pct: number | null;
+    dep_4_pct: number | null;
+    dep_3_count: number;
+    dep_4_count: number;
+    unfiltered_dep_3_pct: number;
+    unfiltered_dep_4_pct: number;
+    min_dep_3_pct: number;
+    max_dep_3_pct: number;
+    min_dep_4_pct: number;
+    max_dep_4_pct: number;
 }
 
 interface BackendEPCAreaData extends EPCRatings {
@@ -242,11 +247,16 @@ export class DashboardService {
 
     public getBuildingsByDeprivationDimension(filter?: AreaFilter): Observable<BackendBuildingsByDeprivationDimensionResponse> {
         const defaultValues: BackendBuildingsByDeprivationDimensionResponse = {
-            dep_0_pct: 0,
-            dep_1_pct: 0,
-            dep_2_pct: 0,
             dep_3_pct: 0,
             dep_4_pct: 0,
+            dep_3_count: 0,
+            dep_4_count: 0,
+            unfiltered_dep_3_pct: 0,
+            unfiltered_dep_4_pct: 0,
+            min_dep_3_pct: 0,
+            max_dep_3_pct: 0,
+            min_dep_4_pct: 0,
+            max_dep_4_pct: 0,
         };
 
         return this.#http

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -87,6 +87,14 @@ export interface BackendNumberOfInDateAndExpiredEpcsResponse {
     active: number;
 }
 
+export interface BackendBuildingsByDeprivationDimensionResponse {
+    dep_0_pct: number;
+    dep_1_pct: number;
+    dep_2_pct: number;
+    dep_3_pct: number;
+    dep_4_pct: number;
+}
+
 interface BackendEPCAreaData extends EPCRatings {
     name: string;
     total: number;
@@ -230,6 +238,29 @@ export class DashboardService {
             params: this.getParamsWithFilter(filter),
             withCredentials: true,
         });
+    }
+
+    public getBuildingsByDeprivationDimension(filter?: AreaFilter): Observable<BackendBuildingsByDeprivationDimensionResponse> {
+        const defaultValues: BackendBuildingsByDeprivationDimensionResponse = {
+            dep_0_pct: 0,
+            dep_1_pct: 0,
+            dep_2_pct: 0,
+            dep_3_pct: 0,
+            dep_4_pct: 0,
+        };
+
+        return this.#http
+            .get<
+                BackendBuildingsByDeprivationDimensionResponse[] | BackendBuildingsByDeprivationDimensionResponse
+            >(`${this.#endpointRoot}/buildings-by-deprivation-dimension`, { params: this.getParamsWithFilter(filter), withCredentials: true })
+            .pipe(
+                map((response) => {
+                    if (Array.isArray(response)) {
+                        return response[0] ?? defaultValues;
+                    }
+                    return response ?? defaultValues;
+                }),
+            );
     }
 
     public getEPCByFeature(feature: string, filter?: AreaFilter): Observable<EPCRatingsByCategory[]> {


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Adds charts for ONS deprivation into dashboards at National, Named Area + Polygon levels.
Look and Feel matches deprivation popup on map layer.

## Description
As above.

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
<img width="385" height="166" alt="image" src="https://github.com/user-attachments/assets/6c0f5939-08de-4020-be89-550a2537f966" />
<img width="382" height="143" alt="image" src="https://github.com/user-attachments/assets/1d001b2a-479c-45fc-99aa-5f4304125837" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
- [x] I have included my changes in the unreleased section of the changelog.
