### PR TITLE
feat(DPAV-1685): hours of sunlight layer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 - [DPAV-2487]: added high deprivation layer and associated popover
 - [DPAV-2499]: added deprivation charts for national + area views
+- [DPAV-1685]: hours of sunlight layer implementation
 
 ## [0.95.1] - 2026-01-22
 

--- a/src/app/components/legend/legend.component.spec.ts
+++ b/src/app/components/legend/legend.component.spec.ts
@@ -51,4 +51,19 @@ describe('LegendComponent', () => {
         expect(component.currentLegend().type).toBe('deprivation');
         expect(component.currentLegend().title).toBe('High Deprivation');
     });
+
+    it('should show sunlight hours legend when sunlight hours layer is active', () => {
+        fixture.componentRef.setInput('layerState', {
+            epc: { region: false, county: false, district: false, ward: false },
+            windDrivenRain: { twoDegree: false, fourDegree: false },
+            icingDays: false,
+            hotSummerDays: false,
+            deprivation: false,
+            sunlightHours: true,
+        });
+        fixture.detectChanges();
+
+        expect(component.currentLegend().type).toBe('sunlight-hours');
+        expect(component.currentLegend().title).toBe('Sunlight Hours');
+    });
 });

--- a/src/app/components/legend/legend.component.ts
+++ b/src/app/components/legend/legend.component.ts
@@ -17,10 +17,11 @@ export interface LayerState {
     icingDays: boolean;
     hotSummerDays: boolean;
     deprivation: boolean;
+    sunlightHours: boolean;
 }
 
 export interface LegendConfig {
-    type: 'epc' | 'wind-driven-rain' | 'hot-summer-days' | 'icing-days' | 'deprivation';
+    type: 'epc' | 'wind-driven-rain' | 'hot-summer-days' | 'icing-days' | 'deprivation' | 'sunlight-hours';
     title: string;
     gradient?: {
         colors: string[];
@@ -70,6 +71,10 @@ export class LegendComponent {
 
         if (layerState.deprivation) {
             return this.getDeprivationLegend();
+        }
+
+        if (layerState.sunlightHours) {
+            return this.getSunlightHoursLegend();
         }
 
         if (layerState.epc.region || layerState.epc.county || layerState.epc.district || layerState.epc.ward) {
@@ -150,6 +155,18 @@ export class LegendComponent {
         return {
             type: 'deprivation',
             title: 'High Deprivation',
+            gradient: {
+                colors: [colors.high, colors.low],
+                labels: ['High', 'Low'],
+            },
+        };
+    }
+
+    private getSunlightHoursLegend(): LegendConfig {
+        const colors = LAYER_COLORS.sunlightHours;
+        return {
+            type: 'sunlight-hours',
+            title: 'Sunlight Hours',
             gradient: {
                 colors: [colors.high, colors.low],
                 labels: ['High', 'Low'],

--- a/src/app/components/map/map.component.html
+++ b/src/app/components/map/map.component.html
@@ -123,6 +123,13 @@
                             <span>High deprivation</span>
                         </button>
                     </div>
+
+                    <div>
+                        <button mat-menu-item (click)="toggleSunlightHoursLayer()" [class.active]="layerStates.sunlightHours">
+                            <mat-icon>sunny</mat-icon>
+                            <span>Sunlight hours</span>
+                        </button>
+                    </div>
                 </mat-menu>
             </div>
         }

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -95,6 +95,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             icingDays: false,
             hotSummerDays: false,
             deprivation: false,
+            sunlightHours: false,
         };
     }
 
@@ -406,6 +407,24 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         }
     }
 
+    public toggleSunlightHoursLayer(): void {
+        const layerId = 'sunlight-hours-layer';
+        const layer = this.#layerFactory.getLayer(layerId);
+
+        if (layer) {
+            if (this.layerStates.sunlightHours) {
+                layer.hide();
+                this.hideOutlineLayer(`${layerId}-outline`);
+                this.layerStates.sunlightHours = false;
+            } else {
+                this.hideAllLayers();
+                layer.show();
+                this.layerStates.sunlightHours = true;
+            }
+            this.updateLayersVisibility();
+        }
+    }
+
     private hideAllLayers(): void {
         this.hideLayerGroup(this.layerStates.epc, 'epc', '-layer');
         this.hideLayerGroup(this.layerStates.epc, 'epc', '-layer-outline');
@@ -434,6 +453,14 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             `${deprivationLayer}-outline`,
             () => this.layerStates.deprivation,
             (value) => (this.layerStates.deprivation = value),
+        );
+
+        const sunlightHoursLayer = 'sunlight-hours-layer';
+        this.hideSingleLayerWithOutline(
+            sunlightHoursLayer,
+            `${sunlightHoursLayer}-outline`,
+            () => this.layerStates.sunlightHours,
+            (value) => (this.layerStates.sunlightHours = value),
         );
     }
 

--- a/src/app/core/config/layer-colors.config.ts
+++ b/src/app/core/config/layer-colors.config.ts
@@ -10,6 +10,7 @@ export interface LayerColorConfig {
     hotSummerDays: LayerColors;
     icingDays: LayerColors;
     deprivation: LayerColors;
+    sunlightHours: LayerColors;
 }
 
 export const LAYER_COLORS: LayerColorConfig = {
@@ -34,6 +35,12 @@ export const LAYER_COLORS: LayerColorConfig = {
     deprivation: {
         low: '#CDE594',
         high: '#080C54',
+        outline: '#ffffff',
+        opacity: 0.8,
+    },
+    sunlightHours: {
+        low: '#464433',
+        high: '#FFF91F',
         outline: '#ffffff',
         opacity: 0.8,
     },

--- a/src/app/core/services/climate-data.service.ts
+++ b/src/app/core/services/climate-data.service.ts
@@ -86,6 +86,16 @@ export interface BuildingExtremeWeatherSummaryData {
     affected_by_wind_driven_rain: boolean;
 }
 
+export interface SunlightHoursProperties {
+    objectid: number;
+    sunlight_hours: number;
+    latitude: number;
+    longitude: number;
+    shape_wkt: string;
+    projection_x_coordinate: number;
+    projection_y_coordinate: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class ClimateDataService {
     readonly #http = inject(HttpClient);
@@ -120,5 +130,9 @@ export class ClimateDataService {
 
     public getExtremeWeatherSummaryData(uprn: string): Observable<BuildingExtremeWeatherSummaryData> {
         return this.#http.get<BuildingExtremeWeatherSummaryData>(`/api/buildings/${uprn}/weather-summary`);
+    }
+
+    public getSunlightHoursLayerData(): Observable<FeatureCollection<Geometry, SunlightHoursProperties>> {
+        return this.#http.get<FeatureCollection<Geometry, SunlightHoursProperties>>(`/api/data/climate/sunlight-hours`);
     }
 }

--- a/src/app/core/services/layers/layer-factory.service.ts
+++ b/src/app/core/services/layers/layer-factory.service.ts
@@ -10,6 +10,7 @@ import { DeprivationLayer } from './deprivation.layer';
 import { EPCLayer } from './epc.layer';
 import { HotSummerDaysLayer } from './hot-summer-days.layer';
 import { IcingDaysLayer } from './icing-days.layer';
+import { SunlightHoursLayer } from './sunlight-hours.layer';
 import { WindDrivenRainLayer, WindDrivenRainLayerConfig } from './wind-driven-rain.layer';
 
 @Injectable({ providedIn: 'root' })
@@ -63,6 +64,9 @@ export class LayerFactoryService {
 
         const deprivationLayer = new DeprivationLayer(this.#demographicsDataService);
         this.layers.set('deprivation-layer', deprivationLayer);
+
+        const sunlightHoursLayer = new SunlightHoursLayer(this.#climateDataService);
+        this.layers.set('sunlight-hours-layer', sunlightHoursLayer);
     }
 
     private initializeEPCLayers(): void {

--- a/src/app/core/services/layers/sunlight-hours.layer.ts
+++ b/src/app/core/services/layers/sunlight-hours.layer.ts
@@ -93,3 +93,7 @@ export class SunlightHoursLayer extends AbstractClimateLayer<SunlightHoursProper
         }
     };
 }
+
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.

--- a/src/app/core/services/layers/sunlight-hours.layer.ts
+++ b/src/app/core/services/layers/sunlight-hours.layer.ts
@@ -1,0 +1,95 @@
+import { LAYER_COLORS } from '@core/config/layer-colors.config';
+import { FeatureCollection, Geometry } from 'geojson';
+import * as mapboxgl from 'mapbox-gl';
+import { LayerSpecification, MapMouseEvent } from 'mapbox-gl';
+import { firstValueFrom } from 'rxjs';
+import { ClimateDataService, SunlightHoursProperties } from '../climate-data.service';
+import { AbstractClimateLayer } from './climate-layer.abstract';
+
+export class SunlightHoursLayer extends AbstractClimateLayer<SunlightHoursProperties> {
+    constructor(private readonly climateDataService: ClimateDataService) {
+        super();
+    }
+
+    public get id(): string {
+        return 'sunlight-hours-layer';
+    }
+
+    public getLayerConfig(): LayerSpecification {
+        if (this.maxValues) {
+            const { min, max } = this.maxValues;
+            return this.createLayerConfig(min, max, LAYER_COLORS.sunlightHours);
+        }
+        return this.createLayerConfig(0, 10, LAYER_COLORS.sunlightHours);
+    }
+
+    public async getSourceData(): Promise<FeatureCollection<Geometry, SunlightHoursProperties>> {
+        try {
+            if (!this.data) {
+                const result = await firstValueFrom(this.climateDataService.getSunlightHoursLayerData());
+                if (result) {
+                    this.data = result;
+                } else {
+                    return this.createEmptyFeatureCollection();
+                }
+            }
+            return this.createFeatureCollectionFromData('sunlight_hours');
+        } catch (error) {
+            console.error(`[SunlightHoursLayer] Error in getSourceData:`, error);
+            return this.createEmptyFeatureCollection();
+        }
+    }
+
+    public override onLayerClick = (event: MapMouseEvent): void => {
+        event.preventDefault();
+
+        const feature = event.features?.[0];
+        if (feature) {
+            const properties = feature.properties as SunlightHoursProperties;
+
+            const popupContent = `
+                    <div class="climate-data-popup">
+                        <div class="popup-header">
+                            <h3>Sunlight hours</h3>
+    
+                            <div class="info-tooltip-container">
+                                <button class="info-button" onclick="togglePopoutInfo()">
+                                    <span class="info-icon">i</span>
+                                </button>
+    
+                                <div id="popout-info" class="info-tooltip" style="display: none;">
+                                    <div class="info-tooltip-header">Hours of sunlight</div>
+                                    <p>
+                                        Mean averages for annual and daily hours of sunlight are taken from the annual hours of sunlight data from 
+                                        2019 to the end of 2024 (inclusive).</p>
+                                    <p>
+                                        Data comes from the Met Office. 
+                                        <a href="https://catalogue.ceda.ac.uk/uuid/4dc8450d889a491ebb20e724debe2dfb/?q=&results_per_page=20&sort_by=title_desc&objects_related_to_uuid=4dc8450d889a491ebb20e724debe2dfb&permissions_option=any&geo_option=True&north_bound=&west_bound=&east_bound=&south_bound=&start_date=&end_date=&date_option=publication_date&start_date_pub=&end_date_pub=">Click here</a>
+                                        to read more about the dataset collection.
+                                    </p>
+                                    <button class="close-button" onclick="hidePopoutInfo()">Close</button>
+                                </div>
+                            </div>
+                        </div>
+    
+                        <div class="data-table">
+                            <dl>
+                                <dt>Average annual hours of sunlight</dt>
+                                <dd>Average daily hours of sunlight</dd>
+
+                                <dd>${properties.sunlight_hours.toFixed(1) || 'N/A'}</dd>
+                                <dd>${(properties.sunlight_hours / 365.25).toFixed(1) || 'N/A'}</dd>
+                            </dl>
+                        </div>
+                    </div>
+                `;
+
+            const popup = new mapboxgl.Popup().setLngLat(event.lngLat).setHTML(popupContent);
+            popup.on('close', () => {
+                this.clearHighlighting(event.target);
+            });
+            this.mapService.registerPopup(popup);
+            this.highlightPolygon(event.target, properties.objectid, 'objectid');
+        }
+    };
+}


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://ndtp.atlassian.net/browse/DPAV-1685
Adds the layer for sunlight hours, along with tooltip functionality when clicking the layer, and a change to the legend component that explains how the gradient of the layer correlates to the data.

## Description
<!--- Describe your changes in detail -->
As above
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested and verified locally manually and with unit test to check that the legend changes when the layer is selected.
## Screenshots (if appropriate):

<img width="1277" height="632" alt="image" src="https://github.com/user-attachments/assets/22a03f65-8913-439b-9666-eb4d40856b22" />

<img width="118" height="144" alt="image" src="https://github.com/user-attachments/assets/f5661d7f-2201-4c76-9588-eeff906f07c5" />

<img width="220" height="113" alt="image" src="https://github.com/user-attachments/assets/910a993b-b30f-486b-9625-99d5d72f379d" />

<img width="275" height="164" alt="image" src="https://github.com/user-attachments/assets/6b103e2a-ec0f-418e-9e2f-6d9c72bf6295" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
- [x] I have included my changes in the unreleased section of the changelog.
