### PR TITLE
feat(dpav-1686): ensured the weather data requests all dont fail if one fails

### DIFF
--- a/src/app/core/models/building.weather.data.model.ts
+++ b/src/app/core/models/building.weather.data.model.ts
@@ -33,8 +33,8 @@ export type BuildingSunlightHoursDataModel = {
 
 export type BuildingWeatherDataModel = {
     uprn: string;
-    buildingWindDrivenRainDataModel: BuildingWindDrivenRainDataModel;
-    buildingHotSummerDaysDataModel: BuildingHotSummerDaysDataModel;
-    buildingIcingDaysDataModel: BuildingIcingDaysDataModel;
-    buildingSunlightHoursDataModel: BuildingSunlightHoursDataModel;
+    buildingWindDrivenRainDataModel?: BuildingWindDrivenRainDataModel;
+    buildingHotSummerDaysDataModel?: BuildingHotSummerDaysDataModel;
+    buildingIcingDaysDataModel?: BuildingIcingDaysDataModel;
+    buildingSunlightHoursDataModel?: BuildingSunlightHoursDataModel;
 };

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -480,7 +480,15 @@ export class DataService {
 
     public setSelectedBuildingWeatherData(buildingWeatherData: BuildingWeatherDataModel): void {
         if (!(buildingWeatherData.uprn in this._selectedBuildingsWeatherDetailsCache.keys())) {
-            this._selectedBuildingsWeatherDetailsCache.set(buildingWeatherData.uprn, buildingWeatherData);
+            // if all weather data is provided then cache the weather details for the building
+            if (
+                buildingWeatherData.buildingWindDrivenRainDataModel &&
+                buildingWeatherData.buildingIcingDaysDataModel &&
+                buildingWeatherData.buildingHotSummerDaysDataModel &&
+                buildingWeatherData.buildingSunlightHoursDataModel
+            ) {
+                this._selectedBuildingsWeatherDetailsCache.set(buildingWeatherData.uprn, buildingWeatherData);
+            }
         }
         this.selectedBuildingWeatherData.set(buildingWeatherData);
     }

--- a/src/app/core/services/utils.service.ts
+++ b/src/app/core/services/utils.service.ts
@@ -17,7 +17,7 @@ import { MapLayerId } from '@core/types/map-layer-id';
 import { booleanWithin } from '@turf/boolean-within';
 import { Polygon } from 'geojson';
 import { ExpressionSpecification, PaintSpecification } from 'mapbox-gl';
-import { forkJoin } from 'rxjs';
+import { catchError, forkJoin, of } from 'rxjs';
 import {
     BuildingHotSummerDaysData,
     BuildingIcingDaysData,
@@ -667,10 +667,30 @@ export class UtilService {
         if (buildingWeatherData) {
             this.#dataService.setSelectedBuildingWeatherData(buildingWeatherData);
         } else {
-            const buildingWindDrivenRainData = this.#climateDataService.getWindDrivenRainBuildingData(UPRN);
-            const buildingHotSummerDaysData = this.#climateDataService.getHotSummerDaysBuildingData(UPRN);
-            const buildingIcingDaysData = this.#climateDataService.getIcingDaysBuildingData(UPRN);
-            const buildingSunlightHoursData = this.#climateDataService.getSunlightHoursData(UPRN);
+            const buildingWindDrivenRainData = this.#climateDataService.getWindDrivenRainBuildingData(UPRN).pipe(
+                catchError((error) => {
+                    console.error(`Error: Unable to fetch wind driven rain data for building with uprn ${UPRN}: ${JSON.stringify(error)}`);
+                    return of(undefined);
+                }),
+            );
+            const buildingHotSummerDaysData = this.#climateDataService.getHotSummerDaysBuildingData(UPRN).pipe(
+                catchError((error) => {
+                    console.error(`Error: Unable to fetch hot summer days data for building with uprn ${UPRN}: ${JSON.stringify(error)}`);
+                    return of(undefined);
+                }),
+            );
+            const buildingIcingDaysData = this.#climateDataService.getIcingDaysBuildingData(UPRN).pipe(
+                catchError((error) => {
+                    console.error(`Error: Unable to fetch icing days data for building with uprn ${UPRN}: ${JSON.stringify(error)}`);
+                    return of(undefined);
+                }),
+            );
+            const buildingSunlightHoursData = this.#climateDataService.getSunlightHoursData(UPRN).pipe(
+                catchError((error) => {
+                    console.error(`Error: Unable to fetch sunlight hours data for building with uprn ${UPRN}: ${JSON.stringify(error)}`);
+                    return of(undefined);
+                }),
+            );
 
             forkJoin([buildingWindDrivenRainData, buildingHotSummerDaysData, buildingIcingDaysData, buildingSunlightHoursData]).subscribe((results) => {
                 this.#dataService.setSelectedBuildingWeatherData(this.mapBuildingWeatherData(UPRN, results[0], results[1], results[2], results[3]));
@@ -733,49 +753,57 @@ export class UtilService {
 
     private mapBuildingWeatherData(
         uprn: string,
-        buildingWindDrivenRainData: BuildingWindDrivenRainData,
-        buildingHotSummerDaysData: BuildingHotSummerDaysData,
-        buildingIcingDaysData: BuildingIcingDaysData,
-        buildingSunlightHoursData: BuildingSunlightHoursData,
+        buildingWindDrivenRainData?: BuildingWindDrivenRainData,
+        buildingHotSummerDaysData?: BuildingHotSummerDaysData,
+        buildingIcingDaysData?: BuildingIcingDaysData,
+        buildingSunlightHoursData?: BuildingSunlightHoursData,
     ): BuildingWeatherDataModel {
-        const windDrivenRainData: BuildingWindDrivenRainDataModel = {
-            northTwoDegreesMedian: buildingWindDrivenRainData.north_two_degrees_median,
-            northEastTwoDegreesMedian: buildingWindDrivenRainData.north_east_two_degrees_median,
-            eastTwoDegreesMedian: buildingWindDrivenRainData.east_two_degrees_median,
-            southEastTwoDegreesMedian: buildingWindDrivenRainData.south_east_two_degrees_median,
-            southTwoDegreesMedian: buildingWindDrivenRainData.south_two_degrees_median,
-            southWestTwoDegreesMedian: buildingWindDrivenRainData.south_west_two_degrees_median,
-            westTwoDegreesMedian: buildingWindDrivenRainData.west_two_degrees_median,
-            northWestTwoDegreesMedian: buildingWindDrivenRainData.north_west_two_degrees_median,
-            northFourDegreesMedian: buildingWindDrivenRainData.north_four_degrees_median,
-            northEastFourDegreesMedian: buildingWindDrivenRainData.north_east_four_degrees_median,
-            eastFourDegreesMedian: buildingWindDrivenRainData.east_four_degrees_median,
-            southEastFourDegreesMedian: buildingWindDrivenRainData.south_east_four_degrees_median,
-            southFourDegreesMedian: buildingWindDrivenRainData.south_four_degrees_median,
-            southWestFourDegreesMedian: buildingWindDrivenRainData.south_west_four_degrees_median,
-            westFourDegreesMedian: buildingWindDrivenRainData.west_four_degrees_median,
-            northWestFourDegreesMedian: buildingWindDrivenRainData.north_west_four_degrees_median,
-        };
+        const windDrivenRainData: BuildingWindDrivenRainDataModel | undefined = buildingWindDrivenRainData
+            ? {
+                  northTwoDegreesMedian: buildingWindDrivenRainData.north_two_degrees_median,
+                  northEastTwoDegreesMedian: buildingWindDrivenRainData.north_east_two_degrees_median,
+                  eastTwoDegreesMedian: buildingWindDrivenRainData.east_two_degrees_median,
+                  southEastTwoDegreesMedian: buildingWindDrivenRainData.south_east_two_degrees_median,
+                  southTwoDegreesMedian: buildingWindDrivenRainData.south_two_degrees_median,
+                  southWestTwoDegreesMedian: buildingWindDrivenRainData.south_west_two_degrees_median,
+                  westTwoDegreesMedian: buildingWindDrivenRainData.west_two_degrees_median,
+                  northWestTwoDegreesMedian: buildingWindDrivenRainData.north_west_two_degrees_median,
+                  northFourDegreesMedian: buildingWindDrivenRainData.north_four_degrees_median,
+                  northEastFourDegreesMedian: buildingWindDrivenRainData.north_east_four_degrees_median,
+                  eastFourDegreesMedian: buildingWindDrivenRainData.east_four_degrees_median,
+                  southEastFourDegreesMedian: buildingWindDrivenRainData.south_east_four_degrees_median,
+                  southFourDegreesMedian: buildingWindDrivenRainData.south_four_degrees_median,
+                  southWestFourDegreesMedian: buildingWindDrivenRainData.south_west_four_degrees_median,
+                  westFourDegreesMedian: buildingWindDrivenRainData.west_four_degrees_median,
+                  northWestFourDegreesMedian: buildingWindDrivenRainData.north_west_four_degrees_median,
+              }
+            : undefined;
 
-        const hotSummerDaysData: BuildingHotSummerDaysDataModel = {
-            baselineMedian: buildingHotSummerDaysData.hsd_baseline,
-            degreesAboveBaselineMedian: new Map([
-                [1.5, buildingHotSummerDaysData.hsd_1_5_degree_above_baseline],
-                [2, buildingHotSummerDaysData.hsd_2_0_degree_above_baseline],
-                [2.5, buildingHotSummerDaysData.hsd_2_5_degree_above_baseline],
-                [3, buildingHotSummerDaysData.hsd_3_0_degree_above_baseline],
-                [4, buildingHotSummerDaysData.hsd_4_0_degree_above_baseline],
-            ]),
-        };
+        const hotSummerDaysData: BuildingHotSummerDaysDataModel | undefined = buildingHotSummerDaysData
+            ? {
+                  baselineMedian: buildingHotSummerDaysData.hsd_baseline,
+                  degreesAboveBaselineMedian: new Map([
+                      [1.5, buildingHotSummerDaysData.hsd_1_5_degree_above_baseline],
+                      [2, buildingHotSummerDaysData.hsd_2_0_degree_above_baseline],
+                      [2.5, buildingHotSummerDaysData.hsd_2_5_degree_above_baseline],
+                      [3, buildingHotSummerDaysData.hsd_3_0_degree_above_baseline],
+                      [4, buildingHotSummerDaysData.hsd_4_0_degree_above_baseline],
+                  ]),
+              }
+            : undefined;
 
-        const icingDaysData: BuildingIcingDaysDataModel = {
-            icingDays: buildingIcingDaysData.icing_days,
-        };
+        const icingDaysData: BuildingIcingDaysDataModel | undefined = buildingIcingDaysData
+            ? {
+                  icingDays: buildingIcingDaysData.icing_days,
+              }
+            : undefined;
 
-        const sunlightHoursData: BuildingSunlightHoursDataModel = {
-            sunlightHours: buildingSunlightHoursData.sunlight_hours,
-            dailySunlightHours: buildingSunlightHoursData.daily_sunlight_hours,
-        };
+        const sunlightHoursData: BuildingSunlightHoursDataModel | undefined = buildingSunlightHoursData
+            ? {
+                  sunlightHours: buildingSunlightHoursData.sunlight_hours,
+                  dailySunlightHours: buildingSunlightHoursData.daily_sunlight_hours,
+              }
+            : undefined;
 
         return {
             uprn: uprn,


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The more info section is built in a way so that not all weather data sections are discarded if information for one of the sections is missing. This however is not the case at the data level and needed to be handled when making requests to fetch the data. This was discovered during testing on dev when the hour of sunlight table was not populated in the geo node.

## Description
<!--- Describe your changes in detail -->
- Changed the type of the individual weather data models to be nullable
- Added a catch error clause to the method that fetch the weather data to log the error and emit an undefined value in the observable
- Added a conditional check to storing selected building weather details in the cache to ensure all the details have been fetched
- Added a check to the mapping method to only map the individual fields of the different weather data models when they are defined

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working as expected

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
