### PR TITLE
feat(dpav-2487): design feedback implemented

### DIFF
--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -243,11 +243,20 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         /** close popup if open and zoom is > 15 and remove selection*/
         this.#mapService.mapInstance.on('zoomend', () => {
             const zoom = this.#mapService.mapInstance.getZoom();
+            const wasShowingLayers = this.#uiStateService.showLayersAndControls();
+            const shouldShowLayers = zoom < 16;
 
             if (zoom < 16) {
                 this.#dataService.clearBuildingsCache();
             }
-            this.#uiStateService.setLayersAndControlsVisibility(zoom < 16);
+
+            this.#uiStateService.setLayersAndControlsVisibility(shouldShowLayers);
+
+            // When zooming to property-level, close any open layer popups.
+            if (wasShowingLayers && !shouldShowLayers) {
+                this.#mapService.clearAllPopups();
+            }
+
             this.updateLayersVisibility();
         });
     }

--- a/src/app/core/services/demographics-data.service.ts
+++ b/src/app/core/services/demographics-data.service.ts
@@ -4,6 +4,7 @@ import { FeatureCollection, Geometry } from 'geojson';
 import { Observable } from 'rxjs';
 
 export interface DeprivationLayerProperties {
+    mlsoa_id?: string;
     area_nm?: string;
     dep_3?: number;
     dep_4?: number;

--- a/src/app/core/services/layers/deprivation.layer.ts
+++ b/src/app/core/services/layers/deprivation.layer.ts
@@ -121,7 +121,7 @@ export class DeprivationLayer extends AbstractClimateLayer<DeprivationLayerPrope
 
         this.mapService.registerPopup(this.currentPopup);
 
-        this.highlightFeature(event.target, feature.id);
+        this.highlightFeature(event.target, properties.mlsoa_id ?? properties.area_nm);
     };
 
     private createHistogram(minPercentage: number, maxPercentage: number, areaPercentage: number): string {
@@ -149,34 +149,56 @@ export class DeprivationLayer extends AbstractClimateLayer<DeprivationLayerPrope
         `;
     }
 
-    private highlightFeature(map: mapboxgl.Map, featureId: string | number | undefined): void {
-        if (featureId === undefined || featureId === null) {
+    private highlightFeature(map: mapboxgl.Map, featureKey: string | undefined): void {
+        if (!featureKey) {
             return;
         }
 
-        map.setPaintProperty(this.id, 'fill-opacity', ['case', ['==', ['id'], featureId], 0.9, 0.6]);
+        const selectedFilter = ['==', ['get', 'mlsoa_id'], featureKey];
+        map.setPaintProperty(this.id, 'fill-opacity', ['case', selectedFilter, 0.9, 0.6]);
 
+        const highlightFillLayerId = `${this.id}-highlight-fill`;
         const outlineLayerId = `${this.id}-outline`;
+
+        if (map.getLayer(highlightFillLayerId)) {
+            map.removeLayer(highlightFillLayerId);
+        }
 
         if (map.getLayer(outlineLayerId)) {
             map.removeLayer(outlineLayerId);
         }
 
         map.addLayer({
+            id: highlightFillLayerId,
+            type: 'fill',
+            source: `${this.id}-source`,
+            paint: {
+                'fill-color': '#ffffff',
+                'fill-opacity': 0.16,
+            },
+            filter: selectedFilter,
+        });
+
+        map.addLayer({
             id: outlineLayerId,
             type: 'line',
             source: `${this.id}-source`,
             paint: {
-                'line-color': '#6666aa',
+                'line-color': '#000000',
                 'line-width': 3,
-                'line-opacity': 0.75,
+                'line-opacity': 1,
             },
-            filter: ['==', ['id'], featureId],
+            filter: selectedFilter,
         });
     }
 
     private clearFeatureHighlight(map: mapboxgl.Map): void {
         map.setPaintProperty(this.id, 'fill-opacity', LAYER_COLORS.deprivation.opacity);
+
+        const highlightFillLayerId = `${this.id}-highlight-fill`;
+        if (map.getLayer(highlightFillLayerId)) {
+            map.removeLayer(highlightFillLayerId);
+        }
 
         const outlineLayerId = `${this.id}-outline`;
         if (map.getLayer(outlineLayerId)) {

--- a/src/styles/_mapbox.scss
+++ b/src/styles/_mapbox.scss
@@ -82,6 +82,9 @@
 
                 .info-tooltip-container {
                     position: relative;
+                    display: inline-flex;
+                    align-items: center;
+                    width: max-content;
 
                     .info-button {
                         display: flex;
@@ -101,8 +104,9 @@
                     .info-tooltip {
                         position: absolute;
                         z-index: 1000;
-                        top: 0;
-                        right: calc(100% + 0.5rem);
+                        top: 50%;
+                        left: calc(100% + 0.5rem);
+                        transform: translateY(-50%);
 
                         width: 18rem;
                         padding: 1rem;


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Design/testing feedback from DPAV-2487 - ONS Deprivation layer

## Description
- Area selected whilst deprivation layer is active is now highlighted
- Info pop moved to right of info button and vertically centred per other popups
- Layer popups removed when user zooms to building level

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
<img width="462" height="307" alt="image" src="https://github.com/user-attachments/assets/8c540e46-f702-40ca-bece-7d62324b6eb6" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [x] I have included my changes in the unreleased section of the changelog.
