### PR TITLE
feat(dpav-2541): added downloadable modal for the sunlight hours layer

### DIFF
--- a/src/app/components/hours-of-sunlight-section-item/hours-of-sunlight-section-item.html
+++ b/src/app/components/hours-of-sunlight-section-item/hours-of-sunlight-section-item.html
@@ -9,6 +9,11 @@
             Solar exposure can also influence internal temperatures and solar gain, which may be relevant when planning insulation, glazing or shading measures.
         </p>
         <p>This information reflects area-level climate data, not site-specific roof analysis.</p>
+        <p class="section-item-warning-guidance-more-info">
+            <strong
+                >For more information, please read <a href="" (click)="$event.preventDefault(); onDownloadableWarningGuidanceMoreInfoClick()">here</a></strong
+            >
+        </p>
         <div class="data-table">
             <dl>
                 <dt>Average annual hours of sunlight</dt>

--- a/src/app/components/hours-of-sunlight-section-item/hours-of-sunlight-section-item.ts
+++ b/src/app/components/hours-of-sunlight-section-item/hours-of-sunlight-section-item.ts
@@ -1,4 +1,7 @@
-import { Component, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { DomSanitizer } from '@angular/platform-browser';
+import { DownloadableContentModal } from '@components/downloadable-content-modal/downloadable-content-modal';
 import { MoreInfoSectionItem } from '@components/more-info-section-item/more-info-section-item';
 import { BuildingSunlightHoursDataModel } from '@core/models/building.weather.data.model';
 
@@ -9,7 +12,28 @@ import { BuildingSunlightHoursDataModel } from '@core/models/building.weather.da
     styleUrl: './hours-of-sunlight-section-item.scss',
 })
 export class HoursOfSunlightSectionItem {
+    readonly #sanitizer = inject(DomSanitizer);
+    readonly #dialog = inject(MatDialog);
+
     public dataInput = input.required<BuildingSunlightHoursDataModel>();
+
+    public readonly downloadableWarningGuidanceMoreInfo = {
+        content: this.#sanitizer.bypassSecurityTrustHtml(`
+            <h2 style="font-weight: 550;">Hours of sunlight and retrofitting UK housing</h2>
+            <div style="display: flex; justify-content: center; padding: 30px;">
+                <p><em>More information coming soon</em></p>
+            </div>
+        `),
+    };
+
+    public onDownloadableWarningGuidanceMoreInfoClick(): void {
+        const dialogRef = this.#dialog.open(DownloadableContentModal, {
+            data: this.downloadableWarningGuidanceMoreInfo,
+            panelClass: 'section-item-warning-guidance-more-info-modal',
+        });
+
+        dialogRef.afterClosed().subscribe();
+    }
 }
 
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dev testing feedback revealed that the more info link also needs to be in the hours of sunlight panel

## Description
<!--- Describe your changes in detail -->
- Added a more info link to the hours of sunlight section item component
- Added a method to open the downloadable content modal with the coming soon content and only the close button 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working as expected

## Screenshots (if appropriate):
<img width="1827" height="829" alt="image" src="https://github.com/user-attachments/assets/ce0a3361-1e3c-4ee1-8510-4d49998a5b30" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.