### PR TITLE
feat(dpav-2498): adjust colour of national average in polygon area chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - [DPAV-2498]: Handle hours of sunlight chart with polygon selection
 - [DPAV-2541]: Completed modal content for all weather sections
 - [DPAV-2541]: Implemented feedback from dev testing for downloadable content modal
-
+- [DPAV-2498]: Adjust colour of national average in polygon area chart
 
 ## [0.95.1] - 2026-01-22
 

--- a/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
@@ -142,7 +142,7 @@ describe('SunlightHoursByAreaChartComponent', () => {
 
             component['sunlightHoursAreaData'].set(dataWithNationalAverage);
 
-            component.selectedAreas.set(dataWithNationalAverage.map(d => d.area_name));
+            component.selectedAreas.set(dataWithNationalAverage.map((d) => d.area_name));
 
             fixture.detectChanges();
 

--- a/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
@@ -134,23 +134,15 @@ describe('SunlightHoursByAreaChartComponent', () => {
             expect(trace.x).toEqual([4.8]);
         });
 
-        it('should colour the "National Average" bar dark blue (#002244)', () => {
+        it('should colour the "National average" bar dark blue (#002244)', () => {
             const dataWithNationalAverage: SunlightHoursRegionData[] = [
-                {
-                    area_name: 'London',
-                    average_daily_sunlight_hours: 4.8,
-                },
-                {
-                    area_name: 'National Average',
-                    average_daily_sunlight_hours: 5.0,
-                },
-                {
-                    area_name: 'South East',
-                    average_daily_sunlight_hours: 5.5,
-                },
+                { area_name: 'Area average', average_daily_sunlight_hours: 4.8 },
+                { area_name: 'National average', average_daily_sunlight_hours: 5.0 },
             ];
 
-            jest.spyOn(dashboardService, 'getAverageDailySunlightHoursPerArea').mockReturnValue(of(dataWithNationalAverage));
+            component['sunlightHoursAreaData'].set(dataWithNationalAverage);
+
+            component.selectedAreas.set(dataWithNationalAverage.map(d => d.area_name));
 
             fixture.detectChanges();
 
@@ -160,7 +152,7 @@ describe('SunlightHoursByAreaChartComponent', () => {
             const yValues = trace.y as string[];
             const colors = trace.marker?.color as string[];
 
-            const nationalIndex = yValues.indexOf('National Average');
+            const nationalIndex = yValues.indexOf('National average');
 
             expect(nationalIndex).toBeGreaterThan(-1);
             expect(colors[nationalIndex]).toBe('#002244');

--- a/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
@@ -133,5 +133,38 @@ describe('SunlightHoursByAreaChartComponent', () => {
 
             expect(trace.x).toEqual([4.8]);
         });
+
+        it('should colour the "National Average" bar dark blue (#002244)', () => {
+            const dataWithNationalAverage: SunlightHoursRegionData[] = [
+                {
+                    area_name: 'London',
+                    average_daily_sunlight_hours: 4.8,
+                },
+                {
+                    area_name: 'National Average',
+                    average_daily_sunlight_hours: 5.0,
+                },
+                {
+                    area_name: 'South East',
+                    average_daily_sunlight_hours: 5.5,
+                },
+            ];
+
+            jest.spyOn(dashboardService, 'getAverageDailySunlightHoursPerArea')
+                .mockReturnValue(of(dataWithNationalAverage));
+
+            fixture.detectChanges();
+
+            const chartData = component.chartData();
+            const trace = chartData[0] as PlotData;
+
+            const yValues = trace.y as string[];
+            const colors = trace.marker?.color as string[];
+
+            const nationalIndex = yValues.indexOf('National Average');
+
+            expect(nationalIndex).toBeGreaterThan(-1);
+            expect(colors[nationalIndex]).toBe('#002244');
+        });
     });
 });

--- a/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
+++ b/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.spec.ts
@@ -150,8 +150,7 @@ describe('SunlightHoursByAreaChartComponent', () => {
                 },
             ];
 
-            jest.spyOn(dashboardService, 'getAverageDailySunlightHoursPerArea')
-                .mockReturnValue(of(dataWithNationalAverage));
+            jest.spyOn(dashboardService, 'getAverageDailySunlightHoursPerArea').mockReturnValue(of(dataWithNationalAverage));
 
             fixture.detectChanges();
 

--- a/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.ts
+++ b/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.ts
@@ -133,7 +133,11 @@ export class SunlightHoursByAreaChartComponent extends ScrollableChartComponent 
                 y: areaNames,
                 orientation: 'h',
                 marker: {
-                    color: '#1f77b4',
+                    color: areaNames.map(name =>
+                        name === 'National average'
+                            ? '#002244'
+                            : '#1f77b4'
+                    )
                 },
             },
         ];

--- a/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.ts
+++ b/src/app/containers/dashboard/charts/sunlight-hours-by-area-chart/sunlight-hours-by-area-chart.component.ts
@@ -133,11 +133,7 @@ export class SunlightHoursByAreaChartComponent extends ScrollableChartComponent 
                 y: areaNames,
                 orientation: 'h',
                 marker: {
-                    color: areaNames.map(name =>
-                        name === 'National average'
-                            ? '#002244'
-                            : '#1f77b4'
-                    )
+                    color: areaNames.map((name) => (name === 'National average' ? '#002244' : '#1f77b4')),
                 },
             },
         ];


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://ndtp.atlassian.net/browse/DPAV-2498
## Description
<!--- Describe your changes in detail -->
Conditional colour added to chart data, sets colour to dark blue if area name is "National average". Unit test assuring this also added.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Manually and with unit test
## Screenshots (if appropriate):
<img width="633" height="484" alt="image" src="https://github.com/user-attachments/assets/24081668-dc58-405f-a64c-03e2d145d21e" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
